### PR TITLE
feat: refine automatic invoice titles

### DIFF
--- a/src/documents/tests/test_vendor_date_renaming.py
+++ b/src/documents/tests/test_vendor_date_renaming.py
@@ -1,5 +1,6 @@
 import datetime
 
+from documents.models import Correspondent
 from documents.models import CustomField
 from documents.models import CustomFieldInstance
 from documents.models import Document
@@ -13,11 +14,15 @@ def create_doc(vendor_field, invoice_field, vendor_value, invoice_value, checksu
     )
     if vendor_value is not None:
         CustomFieldInstance.objects.create(
-            document=doc, field=vendor_field, value_text=vendor_value,
+            document=doc,
+            field=vendor_field,
+            value_text=vendor_value,
         )
     if invoice_value is not None:
         CustomFieldInstance.objects.create(
-            document=doc, field=invoice_field, value_date=invoice_value,
+            document=doc,
+            field=invoice_field,
+            value_date=invoice_value,
         )
     doc.refresh_from_db()
     return doc
@@ -25,49 +30,90 @@ def create_doc(vendor_field, invoice_field, vendor_value, invoice_value, checksu
 
 def test_rename_documents_same_vendor_numbered(db):
     vendor_field = CustomField.objects.create(
-        name="Vendor Name", data_type=CustomField.FieldDataType.STRING,
+        name="Vendor Name",
+        data_type=CustomField.FieldDataType.STRING,
     )
     invoice_field = CustomField.objects.create(
-        name="Invoice Date", data_type=CustomField.FieldDataType.DATE,
+        name="Invoice Date",
+        data_type=CustomField.FieldDataType.DATE,
     )
     date = datetime.date(2024, 10, 2)
 
-    doc1 = create_doc(vendor_field, invoice_field, "Thanos", date, "0" * 32)
-    doc2 = create_doc(vendor_field, invoice_field, "Thanos", date, "1" * 32)
-    doc3 = create_doc(vendor_field, invoice_field, "Thanos", date, "2" * 32)
+    doc1 = create_doc(vendor_field, invoice_field, "ACME_Inc.-West", date, "0" * 32)
+    doc2 = create_doc(vendor_field, invoice_field, "ACME_Inc.-West", date, "1" * 32)
+    doc3 = create_doc(vendor_field, invoice_field, "ACME_Inc.-West", date, "2" * 32)
 
-    assert doc1.title == "Thanos_02-10-2024"
-    assert doc2.title == "Thanos_02-10-2024 (2)"
-    assert doc3.title == "Thanos_02-10-2024 (3)"
+    assert doc1.title == "ACME Inc West 10-02-2024"
+    assert doc2.title == "ACME Inc West 10-02-2024 (2)"
+    assert doc3.title == "ACME Inc West 10-02-2024 (3)"
 
     other_date = datetime.date(2024, 10, 3)
-    doc4 = create_doc(vendor_field, invoice_field, "Thanos", other_date, "3" * 32)
-    assert doc4.title == "Thanos_03-10-2024"
+    doc4 = create_doc(
+        vendor_field,
+        invoice_field,
+        "ACME_Inc.-West",
+        other_date,
+        "3" * 32,
+    )
+    assert doc4.title == "ACME Inc West 10-03-2024"
 
 
 def test_missing_fields_leave_title(db):
     vendor_field = CustomField.objects.create(
-        name="Vendor Name", data_type=CustomField.FieldDataType.STRING,
+        name="Vendor Name",
+        data_type=CustomField.FieldDataType.STRING,
     )
     invoice_field = CustomField.objects.create(
-        name="Invoice Date", data_type=CustomField.FieldDataType.DATE,
+        name="Invoice Date",
+        data_type=CustomField.FieldDataType.DATE,
     )
 
     doc = create_doc(vendor_field, invoice_field, "Thanos", None, "4" * 32)
     assert doc.title == ""
 
     doc2 = create_doc(
-        vendor_field, invoice_field, None, datetime.date(2024, 10, 2), "5" * 32,
+        vendor_field,
+        invoice_field,
+        None,
+        datetime.date(2024, 10, 2),
+        "5" * 32,
     )
     assert doc2.title == ""
 
 
-def test_title_recomputed_on_field_update(db, mocker):
-    vendor_field = CustomField.objects.create(
-        name="Vendor Name", data_type=CustomField.FieldDataType.STRING,
+def test_correspondent_fallback(db):
+    _ = CustomField.objects.create(
+        name="Vendor Name",
+        data_type=CustomField.FieldDataType.STRING,
     )
     invoice_field = CustomField.objects.create(
-        name="Invoice Date", data_type=CustomField.FieldDataType.DATE,
+        name="Invoice Date",
+        data_type=CustomField.FieldDataType.DATE,
+    )
+    corr = Correspondent.objects.create(name="Jose Gutierrez")
+    doc = Document.objects.create(
+        checksum="7" * 32,
+        mime_type="application/pdf",
+        content="",
+        correspondent=corr,
+    )
+    CustomFieldInstance.objects.create(
+        document=doc,
+        field=invoice_field,
+        value_date=datetime.date(2024, 10, 1),
+    )
+    doc.refresh_from_db()
+    assert doc.title == "Jose Gutierrez 10-01-2024"
+
+
+def test_title_recomputed_on_field_update(db, mocker):
+    vendor_field = CustomField.objects.create(
+        name="Vendor Name",
+        data_type=CustomField.FieldDataType.STRING,
+    )
+    invoice_field = CustomField.objects.create(
+        name="Invoice Date",
+        data_type=CustomField.FieldDataType.DATE,
     )
     doc = Document.objects.create(
         checksum="6" * 32,
@@ -76,24 +122,24 @@ def test_title_recomputed_on_field_update(db, mocker):
     )
 
     CustomFieldInstance.objects.create(
-        document=doc, field=vendor_field, value_text="Thanos",
+        document=doc,
+        field=vendor_field,
+        value_text="Thanos",
     )
     doc.refresh_from_db()
     assert doc.title == ""
 
-    with mocker.patch(
-        "documents.signals.handlers.Document.save", wraps=Document.save,
-    ) as mock_save:
-        CustomFieldInstance.objects.create(
-            document=doc, field=invoice_field, value_date=datetime.date(2024, 10, 2),
-        )
-        doc.refresh_from_db()
-        assert doc.title == "Thanos_02-10-2024"
-        assert mock_save.call_count == 1
+    spy = mocker.spy(Document, "save")
+    CustomFieldInstance.objects.create(
+        document=doc,
+        field=invoice_field,
+        value_date=datetime.date(2024, 10, 2),
+    )
+    doc.refresh_from_db()
+    assert doc.title == "Thanos 10-02-2024"
+    assert spy.call_count == 1
 
-    with mocker.patch(
-        "documents.signals.handlers.Document.save", wraps=Document.save,
-    ) as mock_save2:
-        doc.save()
-        assert mock_save2.call_count == 1
-    assert doc.title == "Thanos_02-10-2024"
+    spy.reset_mock()
+    doc.save()
+    assert spy.call_count == 1
+    assert doc.title == "Thanos 10-02-2024"

--- a/src/documents/utils/rename_from_custom_fields.py
+++ b/src/documents/utils/rename_from_custom_fields.py
@@ -3,31 +3,28 @@ from __future__ import annotations
 import datetime
 import re
 
+from django.db.models import Q
+
 from documents.models import CustomField
-from documents.models import CustomFieldInstance
 from documents.models import Document
 
 ILLEGAL_CHARS = r'[\\/:*?"<>|]'
 
 
-def get_cf_value(document: Document, field_name: str):
-    try:
-        field = CustomField.objects.get(name=field_name)
-    except CustomField.DoesNotExist:
-        return None
-    try:
-        instance = document.custom_fields.get(field=field)
-    except CustomFieldInstance.DoesNotExist:
-        return None
-    if field.data_type == CustomField.FieldDataType.DATE:
-        return instance.value_date
-    return instance.value_text
-
-
-def sanitize_vendor(name: str) -> str:
-    name = re.sub(r"\s+", " ", name).strip()
+def clean_vendor(name: str) -> str:
+    name = name.strip()
+    name = re.sub(r"[_\-.]+", " ", name)
     name = re.sub(ILLEGAL_CHARS, "", name)
-    return name.replace(" ", "_")
+    name = re.sub(r"\s+", " ", name)
+    while name and not name[0].isalnum():
+        if name[0] == "(" and ")" in name:
+            break
+        name = name[1:]
+    while name and not name[-1].isalnum():
+        if name[-1] == ")" and "(" in name:
+            break
+        name = name[:-1]
+    return name.strip()
 
 
 def compute_title(document: Document) -> str | None:
@@ -59,15 +56,16 @@ def compute_title(document: Document) -> str | None:
     if not invoice_value:
         return None
 
-    vendor_sanitized = sanitize_vendor(vendor_value)
-    date_str = invoice_value.strftime("%d-%m-%Y")
-    base = f"{vendor_sanitized}_{date_str}"
+    vendor_cleaned = clean_vendor(vendor_value)
+    if not vendor_cleaned:
+        return None
+    date_str = invoice_value.strftime("%m-%d-%Y")
+    base = f"{vendor_cleaned} {date_str}"
 
-    vendor_docs = None
-    if vendor_field and document.custom_fields.filter(field=vendor_field).exists():
+    if vendor_field:
         vendor_docs = Document.objects.filter(
-            custom_fields__field=vendor_field,
-            custom_fields__value_text=vendor_value,
+            Q(custom_fields__field=vendor_field, custom_fields__value_text=vendor_value)
+            | Q(correspondent__name=vendor_value),
         )
     else:
         vendor_docs = Document.objects.filter(correspondent__name=vendor_value)
@@ -86,6 +84,7 @@ def compute_title(document: Document) -> str | None:
     existing = (
         vendor_docs.filter(pk__in=date_docs.values("pk"))
         .exclude(pk=document.pk)
+        .distinct()
         .count()
     )
 


### PR DESCRIPTION
## Summary
- clean vendor names and parse invoice date to compute titles like `Vendor 01-09-2025`
- recompute titles on document and custom field changes
- test renaming behavior, vendor fallback and date formatting

## Testing
- `pre-commit run --files src/documents/utils/rename_from_custom_fields.py src/documents/tests/test_vendor_date_renaming.py`
- `pytest src/documents/tests/test_vendor_date_renaming.py`

------
https://chatgpt.com/codex/tasks/task_e_68c403db519c833085f3bb905861495b