### PR TITLE
Add vendor guardrails and enforce US invoice dates

### DIFF
--- a/src/documents/management/commands/vendor_cleanup.py
+++ b/src/documents/management/commands/vendor_cleanup.py
@@ -1,0 +1,66 @@
+from django.core.management.base import BaseCommand
+
+from documents.models import Correspondent
+from documents.models import CustomField
+from documents.models import CustomFieldInstance
+from documents.models import Document
+from documents.models import Tag
+from documents.utils.vendor_guard import BLOCKLIST
+from documents.utils.vendor_guard import normalize_invoice_date
+from documents.utils.vendor_guard import normalize_name
+
+
+class Command(BaseCommand):
+    help = "Cleanup blocked correspondents and normalize invoice dates"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--dry-run", action="store_true")
+        parser.add_argument("--verbose", action="store_true")
+
+    def handle(self, *args, **opts):
+        dry = opts.get("dry_run")
+        verbose = opts.get("verbose")
+
+        needs_vendor, _ = Tag.objects.get_or_create(name="needs-vendor")
+        needs_date, _ = Tag.objects.get_or_create(name="needs-date")
+
+        # Handle correspondents on blocklist
+        for corr in Correspondent.objects.all():
+            if normalize_name(corr.name) in BLOCKLIST:
+                docs = Document.objects.filter(correspondent=corr)
+                count = docs.count()
+                if verbose:
+                    self.stdout.write(f"Unassigning {count} docs from {corr.name}")
+                if not dry:
+                    docs.update(correspondent=None)
+                    for doc in docs:
+                        doc.tags.add(needs_vendor)
+
+        # Normalize invoice date field if present
+        try:
+            invoice_field = CustomField.objects.get(name__iexact="Invoice Date")
+        except CustomField.DoesNotExist:
+            invoice_field = None
+
+        if (
+            invoice_field
+            and invoice_field.data_type == CustomField.FieldDataType.STRING
+        ):
+            for inst in CustomFieldInstance.objects.filter(field=invoice_field):
+                current = inst.value_text or ""
+                normalized = normalize_invoice_date(current)
+                if normalized:
+                    if normalized != current and not dry:
+                        inst.value_text = normalized
+                        inst.save(update_fields=("value_text",))
+                        if verbose:
+                            self.stdout.write(
+                                f"Normalized date for doc {inst.document_id}",
+                            )
+                else:
+                    if verbose:
+                        self.stdout.write(
+                            f"Could not parse date for doc {inst.document_id}",
+                        )
+                    if not dry:
+                        inst.document.tags.add(needs_date)

--- a/src/documents/signals/handlers.py
+++ b/src/documents/signals/handlers.py
@@ -43,6 +43,7 @@ from documents.models import CustomFieldInstance
 from documents.models import Document
 from documents.models import DocumentType
 from documents.models import MatchingModel
+from documents.models import Note
 from documents.models import PaperlessTask
 from documents.models import SavedView
 from documents.models import Tag
@@ -56,6 +57,10 @@ from documents.permissions import set_permissions_for_object
 from documents.templating.workflows import parse_w_workflow_placeholders
 from documents.utils.date_extract import extract_date
 from documents.utils.rename_from_custom_fields import compute_title
+from documents.utils.vendor_guard import BLOCKLIST
+from documents.utils.vendor_guard import match_correspondent_by_name
+from documents.utils.vendor_guard import normalize_invoice_date
+from documents.utils.vendor_guard import normalize_name
 from documents.utils.vendor_match import match_vendor
 
 if TYPE_CHECKING:
@@ -64,6 +69,65 @@ if TYPE_CHECKING:
     from documents.data_models import DocumentMetadataOverrides
 
 logger = logging.getLogger("paperless.handlers")
+
+NEEDS_VENDOR_TAG = "needs-vendor"
+NEEDS_DATE_TAG = "needs-date"
+
+
+def _ensure_tag(document: Document, tag_name: str) -> None:
+    tag, _ = Tag.objects.get_or_create(name=tag_name)
+    if tag not in document.tags.all():
+        document.tags.add(tag)
+
+
+def _guard_correspondent(document: Document) -> None:
+    if not document.correspondent:
+        return
+    name = document.correspondent.name
+    if normalize_name(name) in BLOCKLIST:
+        document.correspondent = None
+        document.save(update_fields=("correspondent",))
+        _ensure_tag(document, NEEDS_VENDOR_TAG)
+        Note.objects.create(document=document, note=f"Blocked vendor name: {name}")
+
+
+def _auto_assign_correspondent(document: Document) -> None:
+    if document.correspondent_id is not None:
+        return
+    try:
+        cf = CustomField.objects.get(name__iexact="Vendor Name")
+    except CustomField.DoesNotExist:
+        return
+    try:
+        cfi = CustomFieldInstance.objects.get(document=document, field=cf)
+    except CustomFieldInstance.DoesNotExist:
+        return
+    vendor = cfi.value_text or ""
+    norm = normalize_name(vendor)
+    if not vendor or norm in BLOCKLIST:
+        _ensure_tag(document, NEEDS_VENDOR_TAG)
+        return
+    candidates = match_correspondent_by_name(vendor, Correspondent.objects.all())
+    if len(candidates) == 1:
+        document.correspondent = candidates[0]
+        document.save(update_fields=("correspondent",))
+    else:
+        _ensure_tag(document, NEEDS_VENDOR_TAG)
+
+
+def _enforce_invoice_date(instance: CustomFieldInstance) -> None:
+    if normalize_name(instance.field.name) != normalize_name("Invoice Date"):
+        return
+    if instance.field.data_type != CustomField.FieldDataType.STRING:
+        return
+    current = instance.value_text or ""
+    normalized = normalize_invoice_date(current)
+    if normalized:
+        if current != normalized:
+            instance.value_text = normalized
+            instance.save(update_fields=("value_text",))
+    else:
+        _ensure_tag(instance.document, NEEDS_DATE_TAG)
 
 
 def add_inbox_tags(sender, document: Document, logging_group=None, **kwargs):
@@ -368,15 +432,29 @@ def rename_document_from_fields(sender, instance: Document, **kwargs):
         instance.save(update_fields=("title",))
 
 
+@receiver(post_save, sender=Document)
+def vendor_guard_on_document_save(sender, instance: Document, **kwargs):
+    _guard_correspondent(instance)
+    _auto_assign_correspondent(instance)
+
+
 @receiver(post_save, sender=CustomFieldInstance)
 def rename_document_from_field_instance(
-    sender, instance: CustomFieldInstance, **kwargs,
+    sender,
+    instance: CustomFieldInstance,
+    **kwargs,
 ):
     document = instance.document
     new_title = compute_title(document)
     if new_title and document.title != new_title:
         document.title = new_title
         document.save(update_fields=("title",))
+
+
+@receiver(post_save, sender=CustomFieldInstance)
+def vendor_guard_on_field_instance(sender, instance: CustomFieldInstance, **kwargs):
+    _enforce_invoice_date(instance)
+    _auto_assign_correspondent(instance.document)
 
 
 # see empty_trash in documents/tasks.py for signal handling

--- a/src/documents/signals/handlers.py
+++ b/src/documents/signals/handlers.py
@@ -425,17 +425,23 @@ def autofill_correspondent_and_date(
 
 
 @receiver(post_save, sender=Document)
+def vendor_guard_on_document_save(sender, instance: Document, **kwargs):
+    _guard_correspondent(instance)
+    _auto_assign_correspondent(instance)
+
+
+@receiver(post_save, sender=CustomFieldInstance)
+def vendor_guard_on_field_instance(sender, instance: CustomFieldInstance, **kwargs):
+    _enforce_invoice_date(instance)
+    _auto_assign_correspondent(instance.document)
+
+
+@receiver(post_save, sender=Document)
 def rename_document_from_fields(sender, instance: Document, **kwargs):
     new_title = compute_title(instance)
     if new_title and instance.title != new_title:
         instance.title = new_title
         instance.save(update_fields=("title",))
-
-
-@receiver(post_save, sender=Document)
-def vendor_guard_on_document_save(sender, instance: Document, **kwargs):
-    _guard_correspondent(instance)
-    _auto_assign_correspondent(instance)
 
 
 @receiver(post_save, sender=CustomFieldInstance)
@@ -449,12 +455,6 @@ def rename_document_from_field_instance(
     if new_title and document.title != new_title:
         document.title = new_title
         document.save(update_fields=("title",))
-
-
-@receiver(post_save, sender=CustomFieldInstance)
-def vendor_guard_on_field_instance(sender, instance: CustomFieldInstance, **kwargs):
-    _enforce_invoice_date(instance)
-    _auto_assign_correspondent(instance.document)
 
 
 # see empty_trash in documents/tasks.py for signal handling

--- a/src/documents/tests/test_vendor_guardrails.py
+++ b/src/documents/tests/test_vendor_guardrails.py
@@ -111,3 +111,115 @@ def test_invoice_date_enforcement(db):
     cf4.refresh_from_db()
     assert cf4.value_text == "not a date"
     assert {t.name for t in d4.tags.all()} == {"needs-date"}
+
+
+def test_title_from_correspondent_and_date(db):
+    corr = Correspondent.objects.create(name="Jose Gutierrez")
+    date_field = CustomField.objects.create(
+        name="Invoice Date",
+        data_type=CustomField.FieldDataType.STRING,
+    )
+    doc = Document.objects.create(
+        checksum="8" * 32,
+        mime_type="application/pdf",
+        correspondent=corr,
+        content="",
+    )
+    CustomFieldInstance.objects.create(
+        document=doc,
+        field=date_field,
+        value_text="2023-01-10",
+    )
+    doc.refresh_from_db()
+    assert doc.title == "Jose Gutierrez 01-10-2023"
+
+
+def test_title_cleaning(db):
+    corr = Correspondent.objects.create(name="All American Sign Company, Inc.")
+    date_field = CustomField.objects.create(
+        name="Invoice Date",
+        data_type=CustomField.FieldDataType.STRING,
+    )
+    doc = Document.objects.create(
+        checksum="9" * 32,
+        mime_type="application/pdf",
+        correspondent=corr,
+        content="",
+    )
+    CustomFieldInstance.objects.create(
+        document=doc,
+        field=date_field,
+        value_text="08/12/2024",
+    )
+    doc.refresh_from_db()
+    assert doc.title == "All American Sign Company Inc 08-12-2024"
+
+
+def test_title_blocked_vendor(db):
+    corr = Correspondent.objects.create(name="Oak_Wantana")
+    date_field = CustomField.objects.create(
+        name="Invoice Date",
+        data_type=CustomField.FieldDataType.STRING,
+    )
+    doc = Document.objects.create(
+        checksum="a" * 32,
+        mime_type="application/pdf",
+        correspondent=corr,
+        content="",
+    )
+    CustomFieldInstance.objects.create(
+        document=doc,
+        field=date_field,
+        value_text="07-24-2024",
+    )
+    doc.refresh_from_db()
+    assert doc.title == ""
+
+
+def test_title_duplicate_suffix(db):
+    corr = Correspondent.objects.create(name="Jose Gutierrez")
+    date_field = CustomField.objects.create(
+        name="Invoice Date",
+        data_type=CustomField.FieldDataType.STRING,
+    )
+    d1 = Document.objects.create(
+        checksum="b" * 32,
+        mime_type="application/pdf",
+        correspondent=corr,
+        content="",
+    )
+    CustomFieldInstance.objects.create(
+        document=d1,
+        field=date_field,
+        value_text="1/10/23",
+    )
+    d1.refresh_from_db()
+    assert d1.title == "Jose Gutierrez 01-10-2023"
+
+    d2 = Document.objects.create(
+        checksum="c" * 32,
+        mime_type="application/pdf",
+        correspondent=corr,
+        content="",
+    )
+    CustomFieldInstance.objects.create(
+        document=d2,
+        field=date_field,
+        value_text="01-10-2023",
+    )
+    d2.refresh_from_db()
+    assert d2.title == "Jose Gutierrez 01-10-2023 (2)"
+
+    d3 = Document.objects.create(
+        checksum="d" * 32,
+        mime_type="application/pdf",
+        correspondent=corr,
+        content="",
+    )
+    CustomFieldInstance.objects.create(
+        document=d3,
+        field=date_field,
+        value_text="01-10-2023",
+    )
+    d3.refresh_from_db()
+    assert d3.title == "Jose Gutierrez 01-10-2023 (3)"

--- a/src/documents/tests/test_vendor_guardrails.py
+++ b/src/documents/tests/test_vendor_guardrails.py
@@ -1,0 +1,113 @@
+from documents.models import Correspondent
+from documents.models import CustomField
+from documents.models import CustomFieldInstance
+from documents.models import Document
+
+
+def create_doc(checksum):
+    return Document.objects.create(
+        checksum=checksum,
+        mime_type="application/pdf",
+        content="",
+    )
+
+
+def test_blocked_correspondent_assignment(db):
+    corr = Correspondent.objects.create(name="Private")
+    doc = Document.objects.create(
+        checksum="0" * 32,
+        mime_type="application/pdf",
+        correspondent=corr,
+        content="",
+    )
+    doc.refresh_from_db()
+    assert doc.correspondent is None
+    assert {t.name for t in doc.tags.all()} == {"needs-vendor"}
+
+
+def test_blocked_correspondent_creation(db):
+    corr = Correspondent.objects.create(name="Gourmet Pie")
+    doc = Document.objects.create(
+        checksum="1" * 32,
+        mime_type="application/pdf",
+        correspondent=corr,
+        content="",
+    )
+    doc.refresh_from_db()
+    assert doc.correspondent is None
+    assert {t.name for t in doc.tags.all()} == {"needs-vendor"}
+
+
+def test_auto_assign_from_custom_field(db):
+    corr = Correspondent.objects.create(name="Puritan Bakery Inc")
+    vendor_field = CustomField.objects.create(
+        name="Vendor Name",
+        data_type=CustomField.FieldDataType.STRING,
+    )
+    doc = create_doc("2" * 32)
+    CustomFieldInstance.objects.create(
+        document=doc,
+        field=vendor_field,
+        value_text="Puritan Bakery, Inc.",
+    )
+    doc.refresh_from_db()
+    assert doc.correspondent == corr
+
+
+def test_blocked_vendor_name_from_custom_field(db):
+    vendor_field = CustomField.objects.create(
+        name="Vendor Name",
+        data_type=CustomField.FieldDataType.STRING,
+    )
+    doc = create_doc("3" * 32)
+    CustomFieldInstance.objects.create(
+        document=doc,
+        field=vendor_field,
+        value_text="Oak Wantana",
+    )
+    doc.refresh_from_db()
+    assert doc.correspondent is None
+    assert {t.name for t in doc.tags.all()} == {"needs-vendor"}
+
+
+def test_invoice_date_enforcement(db):
+    date_field = CustomField.objects.create(
+        name="Invoice Date",
+        data_type=CustomField.FieldDataType.STRING,
+    )
+    d1 = create_doc("4" * 32)
+    cf1 = CustomFieldInstance.objects.create(
+        document=d1,
+        field=date_field,
+        value_text="2024-08-06",
+    )
+    cf1.refresh_from_db()
+    assert cf1.value_text == "08-06-2024"
+
+    d2 = create_doc("5" * 32)
+    cf2 = CustomFieldInstance.objects.create(
+        document=d2,
+        field=date_field,
+        value_text="9/8/25 4:04 AM",
+    )
+    cf2.refresh_from_db()
+    assert cf2.value_text == "09-08-2025"
+
+    d3 = create_doc("6" * 32)
+    cf3 = CustomFieldInstance.objects.create(
+        document=d3,
+        field=date_field,
+        value_text="08/09/2025",
+    )
+    cf3.refresh_from_db()
+    assert cf3.value_text == "08-09-2025"
+
+    d4 = create_doc("7" * 32)
+    cf4 = CustomFieldInstance.objects.create(
+        document=d4,
+        field=date_field,
+        value_text="not a date",
+    )
+    cf4.refresh_from_db()
+    assert cf4.value_text == "not a date"
+    assert {t.name for t in d4.tags.all()} == {"needs-date"}

--- a/src/documents/utils/rename_from_custom_fields.py
+++ b/src/documents/utils/rename_from_custom_fields.py
@@ -1,94 +1,97 @@
 from __future__ import annotations
 
-import datetime
 import re
 
 from documents.models import CustomField
-from documents.models import CustomFieldInstance
 from documents.models import Document
+from documents.utils.vendor_guard import BLOCKLIST
+from documents.utils.vendor_guard import normalize_invoice_date
+from documents.utils.vendor_guard import normalize_name
 
 ILLEGAL_CHARS = r'[\\/:*?"<>|]'
 
 
-def get_cf_value(document: Document, field_name: str):
-    try:
-        field = CustomField.objects.get(name=field_name)
-    except CustomField.DoesNotExist:
-        return None
-    try:
-        instance = document.custom_fields.get(field=field)
-    except CustomFieldInstance.DoesNotExist:
-        return None
-    if field.data_type == CustomField.FieldDataType.DATE:
-        return instance.value_date
-    return instance.value_text
-
-
-def sanitize_vendor(name: str) -> str:
-    name = re.sub(r"\s+", " ", name).strip()
+def _clean_correspondent(name: str) -> str:
+    name = name.strip()
+    name = re.sub(r"[_-]+", " ", name)
     name = re.sub(ILLEGAL_CHARS, "", name)
-    return name.replace(" ", "_")
+    name = re.sub(r"[.,]", "", name)
+    name = re.sub(r"\s+", " ", name)
+    return name.strip(" &+,'().")
 
 
 def compute_title(document: Document) -> str | None:
-    vendor_field = CustomField.objects.filter(name="Vendor Name").first()
-    invoice_field = CustomField.objects.filter(name="Invoice Date").first()
+    vendor_cf = CustomField.objects.filter(name__iexact="Vendor Name").first()
+    invoice_cf = CustomField.objects.filter(name__iexact="Invoice Date").first()
 
-    vendor_value = None
-    if vendor_field:
-        vendor_instance = document.custom_fields.filter(field=vendor_field).first()
-        if vendor_instance:
-            vendor_value = vendor_instance.value_text
-    if not vendor_value and document.correspondent:
-        vendor_value = document.correspondent.name
-    if not vendor_value:
+    vendor = None
+    if document.correspondent:
+        vendor = getattr(
+            document.correspondent,
+            "display_name",
+            document.correspondent.name,
+        )
+    elif vendor_cf:
+        inst = document.custom_fields.filter(field=vendor_cf).first()
+        if inst:
+            vendor = inst.value_text
+    if not vendor or normalize_name(vendor) in BLOCKLIST:
         return None
 
-    invoice_value = None
-    if invoice_field:
-        invoice_instance = document.custom_fields.filter(field=invoice_field).first()
-        if invoice_instance:
-            if invoice_field.data_type == CustomField.FieldDataType.DATE:
-                invoice_value = invoice_instance.value_date
-            else:
-                text = invoice_instance.value_text
-                try:
-                    invoice_value = datetime.date.fromisoformat(text)
-                except ValueError:
-                    return None
-    if not invoice_value:
+    clean_vendor = _clean_correspondent(vendor)
+    if not clean_vendor:
         return None
 
-    vendor_sanitized = sanitize_vendor(vendor_value)
-    date_str = invoice_value.strftime("%d-%m-%Y")
-    base = f"{vendor_sanitized}_{date_str}"
+    if not invoice_cf:
+        return None
+    inst = document.custom_fields.filter(field=invoice_cf).first()
+    if not inst:
+        return None
 
-    vendor_docs = None
-    if vendor_field and document.custom_fields.filter(field=vendor_field).exists():
-        vendor_docs = Document.objects.filter(
-            custom_fields__field=vendor_field,
-            custom_fields__value_text=vendor_value,
+    if invoice_cf.data_type == CustomField.FieldDataType.DATE:
+        if not inst.value_date:
+            return None
+        date_str = inst.value_date.strftime("%m-%d-%Y")
+        date_filter = {
+            "custom_fields__field": invoice_cf,
+            "custom_fields__value_date": inst.value_date,
+        }
+    else:
+        date_str = normalize_invoice_date(inst.value_text)
+        if not date_str:
+            return None
+        date_filter = {
+            "custom_fields__field": invoice_cf,
+            "custom_fields__value_text": date_str,
+        }
+
+    base = f"{clean_vendor} {date_str}"
+    docs_same_date = Document.objects.filter(**date_filter)
+
+    duplicates = 0
+    if document.correspondent_id is not None:
+        duplicates = (
+            docs_same_date.filter(correspondent_id=document.correspondent_id)
+            .exclude(pk=document.pk)
+            .count()
         )
     else:
-        vendor_docs = Document.objects.filter(correspondent__name=vendor_value)
+        qs = docs_same_date.exclude(pk=document.pk).select_related("correspondent")
+        for other in qs:
+            other_name = None
+            if other.correspondent:
+                other_name = getattr(
+                    other.correspondent,
+                    "display_name",
+                    other.correspondent.name,
+                )
+            elif vendor_cf:
+                other_inst = other.custom_fields.filter(field=vendor_cf).first()
+                if other_inst:
+                    other_name = other_inst.value_text
+            if other_name and _clean_correspondent(other_name) == clean_vendor:
+                duplicates += 1
 
-    if invoice_field.data_type == CustomField.FieldDataType.DATE:
-        date_docs = Document.objects.filter(
-            custom_fields__field=invoice_field,
-            custom_fields__value_date=invoice_value,
-        )
-    else:
-        date_docs = Document.objects.filter(
-            custom_fields__field=invoice_field,
-            custom_fields__value_text=invoice_value.isoformat(),
-        )
-
-    existing = (
-        vendor_docs.filter(pk__in=date_docs.values("pk"))
-        .exclude(pk=document.pk)
-        .count()
-    )
-
-    if existing == 0:
-        return base
-    return f"{base} ({existing + 1})"
+    if duplicates:
+        return f"{base} ({duplicates + 1})"
+    return base

--- a/src/documents/utils/vendor_guard.py
+++ b/src/documents/utils/vendor_guard.py
@@ -1,0 +1,73 @@
+import re
+
+from dateutil import parser
+from rapidfuzz import fuzz
+
+BLOCKED_NAMES_RAW = {
+    "private",
+    "unknown",
+    "n/a",
+    "misc",
+    "none",
+    "oak",
+    "oak wantana",
+    "gourmet",
+    "gourmet pie",
+    "gourmet cafe",
+    "gourmet pie cafe",
+    "gourmet pie & cafe",
+}
+
+
+def normalize_name(value: str | None) -> str:
+    if not value:
+        return ""
+    value = value.lower().strip()
+    value = re.sub(r"[_\-,:]", " ", value)
+    # remove periods not between letters or numbers
+    value = re.sub(r"(?<![\w])\.(?![\w])", " ", value)
+    value = re.sub(r"(?<=\s)\.(?=\w)|(?<=\w)\.(?=\s)|(?<=\w)\.(?=$)", " ", value)
+    value = re.sub(r"\s+", " ", value)
+    return value
+
+
+BLOCKLIST = {normalize_name(n) for n in BLOCKED_NAMES_RAW}
+
+
+def same_normalized(a: str | None, b: str | None) -> bool:
+    return normalize_name(a) == normalize_name(b)
+
+
+def normalize_invoice_date(value: str | None) -> str | None:
+    if not value:
+        return None
+    value = value.strip()
+    if re.fullmatch(r"\d{2}-\d{2}-\d{4}", value):
+        return value
+    try:
+        dt = parser.parse(value, dayfirst=False, yearfirst=False, fuzzy=True)
+    except Exception:
+        return None
+    if not re.search(r"\d{4}", value):
+        m = re.search(r"(\d{1,2})[/-](\d{1,2})[/-](\d{2})(?!\d)", value)
+        if m:
+            year = int(m.group(3))
+            if year <= 49:
+                year += 2000
+            else:
+                year += 1900
+            dt = dt.replace(year=year)
+    return dt.strftime("%m-%d-%Y")
+
+
+def match_correspondent_by_name(name: str, correspondents) -> list:
+    norm = normalize_name(name)
+    matches = []
+    for corr in correspondents:
+        corr_norm = normalize_name(corr.name)
+        if norm == corr_norm:
+            return [corr]
+        score = fuzz.ratio(norm, corr_norm) / 100.0
+        if score >= 0.86:
+            matches.append(corr)
+    return matches


### PR DESCRIPTION
## Summary
- prevent blocked vendor names and auto-assign from vendor custom field
- normalize invoice dates to MM-DD-YYYY and tag unparseable values
- add cleanup management command and tests

## Testing
- `.venv/bin/pre-commit run --files src/documents/signals/handlers.py src/documents/utils/vendor_guard.py src/documents/management/commands/vendor_cleanup.py src/documents/tests/test_vendor_guardrails.py`
- `.venv/bin/pytest src/documents/tests/test_vendor_guardrails.py`


------
https://chatgpt.com/codex/tasks/task_e_68c477661df08330920a6ffd60a5f228