### PR TITLE
Add OCR-based vendor guard for insufficient text

### DIFF
--- a/src/documents/signals/handlers.py
+++ b/src/documents/signals/handlers.py
@@ -56,6 +56,7 @@ from documents.permissions import get_objects_for_user_owner_aware
 from documents.permissions import set_permissions_for_object
 from documents.templating.workflows import parse_w_workflow_placeholders
 from documents.utils.date_extract import extract_date
+from documents.utils.ocr_stats import get_ocr_stats
 from documents.utils.rename_from_custom_fields import compute_title
 from documents.utils.vendor_guard import BLOCKLIST
 from documents.utils.vendor_guard import match_correspondent_by_name
@@ -72,12 +73,19 @@ logger = logging.getLogger("paperless.handlers")
 
 NEEDS_VENDOR_TAG = "needs-vendor"
 NEEDS_DATE_TAG = "needs-date"
+UNIDENTIFIED_NAME = "Unidentified"
 
 
 def _ensure_tag(document: Document, tag_name: str) -> None:
     tag, _ = Tag.objects.get_or_create(name=tag_name)
     if tag not in document.tags.all():
         document.tags.add(tag)
+
+
+def _remove_tag(document: Document, tag_name: str) -> None:
+    tag = Tag.objects.filter(name=tag_name).first()
+    if tag and tag in document.tags.all():
+        document.tags.remove(tag)
 
 
 def _guard_correspondent(document: Document) -> None:
@@ -113,6 +121,24 @@ def _auto_assign_correspondent(document: Document) -> None:
         document.save(update_fields=("correspondent",))
     else:
         _ensure_tag(document, NEEDS_VENDOR_TAG)
+
+
+def _set_unidentified(document: Document) -> None:
+    corr, _ = Correspondent.objects.get_or_create(name=UNIDENTIFIED_NAME)
+    if document.correspondent != corr:
+        document.correspondent = corr
+        document.save(update_fields=("correspondent",))
+    cf = CustomField.objects.filter(name__iexact="Vendor Name").first()
+    if cf is None:
+        cf = CustomField.objects.create(
+            name="Vendor Name",
+            data_type=CustomField.FieldDataType.STRING,
+        )
+    cfi, _ = CustomFieldInstance.objects.get_or_create(document=document, field=cf)
+    if cfi.value_text != UNIDENTIFIED_NAME:
+        cfi.value_text = UNIDENTIFIED_NAME
+        cfi.save(update_fields=("value_text",))
+    _ensure_tag(document, NEEDS_VENDOR_TAG)
 
 
 def _enforce_invoice_date(instance: CustomFieldInstance) -> None:
@@ -427,7 +453,28 @@ def autofill_correspondent_and_date(
 @receiver(post_save, sender=Document)
 def vendor_guard_on_document_save(sender, instance: Document, **kwargs):
     _guard_correspondent(instance)
+    first, overall = get_ocr_stats(instance.source_path, instance.content or "")
+    small = (
+        first.word_count < 10
+        or first.char_count < 30
+        or not first.has_text_layer
+        or overall.word_count < 10
+        or overall.char_count < 30
+        or not overall.has_text_layer
+    )
+    if small:
+        if not instance.correspondent or normalize_name(
+            instance.correspondent.name,
+        ) == normalize_name(UNIDENTIFIED_NAME):
+            _set_unidentified(instance)
+        else:
+            _remove_tag(instance, NEEDS_VENDOR_TAG)
+        return
     _auto_assign_correspondent(instance)
+    if instance.correspondent and normalize_name(
+        instance.correspondent.name,
+    ) != normalize_name(UNIDENTIFIED_NAME):
+        _remove_tag(instance, NEEDS_VENDOR_TAG)
 
 
 @receiver(post_save, sender=CustomFieldInstance)

--- a/src/documents/tests/test_vendor_guardrails.py
+++ b/src/documents/tests/test_vendor_guardrails.py
@@ -2,6 +2,7 @@ from documents.models import Correspondent
 from documents.models import CustomField
 from documents.models import CustomFieldInstance
 from documents.models import Document
+from documents.utils.ocr_stats import OCRStats
 
 
 def create_doc(checksum):
@@ -223,3 +224,51 @@ def test_title_duplicate_suffix(db):
     )
     d3.refresh_from_db()
     assert d3.title == "Jose Gutierrez 01-10-2023 (3)"
+
+
+def test_small_ocr_sets_unidentified(db, monkeypatch):
+    def fake_stats(path, content):
+        return (
+            OCRStats(word_count=5, char_count=25, has_text_layer=True),
+            OCRStats(word_count=5, char_count=25, has_text_layer=True),
+        )
+
+    monkeypatch.setattr(
+        "documents.signals.handlers.get_ocr_stats",
+        fake_stats,
+    )
+    doc = Document.objects.create(
+        checksum="e" * 32,
+        mime_type="application/pdf",
+        content="",
+    )
+    doc.refresh_from_db()
+    assert doc.correspondent.name == "Unidentified"
+    cf = CustomField.objects.get(name="Vendor Name")
+    cfi = CustomFieldInstance.objects.get(document=doc, field=cf)
+    assert cfi.value_text == "Unidentified"
+    assert {t.name for t in doc.tags.all()} == {"needs-vendor"}
+
+
+def test_remove_needs_vendor_tag(db, monkeypatch):
+    def fake_stats(path, content):
+        return (
+            OCRStats(word_count=0, char_count=0, has_text_layer=False),
+            OCRStats(word_count=0, char_count=0, has_text_layer=False),
+        )
+
+    monkeypatch.setattr(
+        "documents.signals.handlers.get_ocr_stats",
+        fake_stats,
+    )
+    doc = Document.objects.create(
+        checksum="f" * 32,
+        mime_type="application/pdf",
+        content="",
+    )
+    corr = Correspondent.objects.create(name="Acme Corp")
+    doc.correspondent = corr
+    doc.save(update_fields=("correspondent",))
+    doc.refresh_from_db()
+    assert doc.correspondent == corr
+    assert {t.name for t in doc.tags.all()} == set()

--- a/src/documents/utils/ocr_stats.py
+++ b/src/documents/utils/ocr_stats.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path  # noqa: TC003
+
+from documents.utils import run_subprocess
+
+
+@dataclass
+class OCRStats:
+    word_count: int
+    char_count: int
+    has_text_layer: bool
+
+
+def get_ocr_stats(source_path: Path, content: str | None) -> tuple[OCRStats, OCRStats]:
+    """Return OCR statistics for the first page and overall document.
+
+    Args:
+        source_path: Path to the original PDF file.
+        content: OCR text for the entire document.
+    """
+    first = OCRStats(word_count=0, char_count=0, has_text_layer=False)
+    if source_path and source_path.is_file():
+        try:
+            proc = run_subprocess(
+                [
+                    "pdftotext",
+                    "-f",
+                    "1",
+                    "-l",
+                    "1",
+                    str(source_path),
+                    "-",
+                ],
+                check_exit_code=False,
+                log_stdout=False,
+                log_stderr=False,
+            )
+            text = proc.stdout.decode("utf-8", errors="ignore")
+            first = OCRStats(
+                word_count=len(text.split()),
+                char_count=len(text),
+                has_text_layer=bool(text.strip()),
+            )
+        except Exception:
+            first = OCRStats(
+                word_count=0,
+                char_count=0,
+                has_text_layer=False,
+            )
+    overall_content = content or ""
+    overall = OCRStats(
+        word_count=len(overall_content.split()),
+        char_count=len(overall_content),
+        has_text_layer=bool(overall_content.strip()),
+    )
+    return first, overall


### PR DESCRIPTION
## Summary
- compute OCR stats for first page and full document
- guard vendor assignment: default to Unidentified and tag when OCR text is too small
- clear needs-vendor tag when a correspondent is later set

## Testing
- `pre-commit run --files src/documents/utils/ocr_stats.py src/documents/signals/handlers.py src/documents/tests/test_vendor_guardrails.py`
- `pytest -q src/documents/tests/test_vendor_guardrails.py` *(fails: No module named 'dateparser')*


------
https://chatgpt.com/codex/tasks/task_e_68c4a0bede688330ae20d7fbdf5196b8