### PR TITLE
enforce match-only correspondents and improve OCR preprocessing

### DIFF
--- a/src/documents/signals/handlers.py
+++ b/src/documents/signals/handlers.py
@@ -106,13 +106,21 @@ def _auto_assign_correspondent(document: Document) -> None:
     norm = normalize_name(vendor)
     if not vendor or norm in BLOCKLIST:
         _ensure_tag(document, NEEDS_VENDOR_TAG)
+        Note.objects.create(
+            document=document, note=f"blocked correspondent creation: {vendor}",
+        )
         return
     candidates = match_correspondent_by_name(vendor, Correspondent.objects.all())
     if len(candidates) == 1:
-        document.correspondent = candidates[0]
-        document.save(update_fields=("correspondent",))
+        selected = candidates[0]
+        if document.correspondent != selected:
+            document.correspondent = selected
+            document.save(update_fields=("correspondent",))
     else:
         _ensure_tag(document, NEEDS_VENDOR_TAG)
+        Note.objects.create(
+            document=document, note=f"blocked correspondent creation: {vendor}",
+        )
 
 
 def _enforce_invoice_date(instance: CustomFieldInstance) -> None:
@@ -410,9 +418,15 @@ def autofill_correspondent_and_date(
     if not instance.correspondent:
         name = match_vendor(text)
         if name:
-            correspondent, _ = Correspondent.objects.get_or_create(name=name)
-            instance.correspondent = correspondent
-            changed.append("correspondent")
+            candidates = match_correspondent_by_name(name, Correspondent.objects.all())
+            if len(candidates) == 1:
+                instance.correspondent = candidates[0]
+                changed.append("correspondent")
+            else:
+                _ensure_tag(instance, NEEDS_VENDOR_TAG)
+                Note.objects.create(
+                    document=instance, note=f"blocked correspondent creation: {name}",
+                )
 
     if instance.created is None or instance.created == datetime.date.today():
         iso_date = extract_date(text)

--- a/src/documents/tests/test_ocr_processing.py
+++ b/src/documents/tests/test_ocr_processing.py
@@ -1,0 +1,48 @@
+from PIL import Image
+
+from documents.models import Document, Note
+from documents.utils.ocr import ocr_page, process_document_images
+
+
+class Engine:
+    def __init__(self, mapping):
+        self.mapping = mapping
+
+    def image_to_string(self, img):
+        angle = img.info.get("rotation", 0)
+        return self.mapping.get(angle, "")
+
+
+def test_rotation_selects_best(db):
+    engine = Engine({0: "hello", 90: "x" * 180})
+    img = Image.new("RGB", (10, 10), "white")
+    result = ocr_page(img, ocr_engine=engine)
+    assert result["rotation"] == 90
+    assert result["char_count"] == 180
+    doc = Document.objects.create(checksum="r" * 32, mime_type="application/pdf", content="")
+    process_document_images(doc, [img], ocr_engine=engine)
+    doc.refresh_from_db()
+    assert doc.page_count == 1
+    assert Note.objects.filter(document=doc, note="auto-rotated page 1: 90°").exists()
+
+
+def test_blank_page_removed(db):
+    engine = Engine({0: "", 90: "", 180: "", 270: ""})
+    img = Image.new("L", (50, 50), "white")
+    img.putpixel((0, 0), 0)
+    doc = Document.objects.create(checksum="s" * 32, mime_type="application/pdf", content="")
+    process_document_images(doc, [img], ocr_engine=engine)
+    doc.refresh_from_db()
+    assert doc.page_count == 0
+    assert Note.objects.filter(document=doc, note="removed blank page 1").exists()
+
+
+def test_all_blank_document_tagged(db):
+    engine = Engine({0: "", 90: "", 180: "", 270: ""})
+    img = Image.new("L", (50, 50), "white")
+    doc = Document.objects.create(checksum="t" * 32, mime_type="application/pdf", content="")
+    process_document_images(doc, [img, img.copy()], ocr_engine=engine)
+    doc.refresh_from_db()
+    assert doc.page_count == 0
+    assert {t.name for t in doc.tags.all()} == {"blank-document"}
+    assert doc.correspondent is None

--- a/src/documents/tests/test_vendor_guardrails.py
+++ b/src/documents/tests/test_vendor_guardrails.py
@@ -2,6 +2,7 @@ from documents.models import Correspondent
 from documents.models import CustomField
 from documents.models import CustomFieldInstance
 from documents.models import Document
+from documents.models import Note
 
 
 def create_doc(checksum):
@@ -36,6 +37,20 @@ def test_blocked_correspondent_creation(db):
     doc.refresh_from_db()
     assert doc.correspondent is None
     assert {t.name for t in doc.tags.all()} == {"needs-vendor"}
+
+
+def test_match_only_correspondent_no_creation(db, monkeypatch):
+    monkeypatch.setattr(
+        "documents.utils.vendor_match.match_vendor", lambda text: "Acme West"
+    )
+    doc = create_doc("d" * 32)
+    doc.refresh_from_db()
+    assert doc.correspondent is None
+    assert {t.name for t in doc.tags.all()} == {"needs-vendor"}
+    assert not Correspondent.objects.filter(name="Acme West").exists()
+    assert Note.objects.filter(
+        document=doc, note="blocked correspondent creation: Acme West"
+    ).exists()
 
 
 def test_auto_assign_from_custom_field(db):

--- a/src/documents/utils/ocr.py
+++ b/src/documents/utils/ocr.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import Iterable, Tuple
+
+from PIL import Image
+
+from documents.models import Document, Note, Tag
+
+BLANK_DOCUMENT_TAG = "blank-document"
+
+
+def _pytesseract():  # pragma: no cover - replaced in tests
+    import pytesseract
+    return pytesseract
+
+
+def _ink_coverage(image: Image.Image) -> float:
+    gray = image.convert("L").resize((50, 50))
+    pixels = list(gray.getdata())
+    nonwhite = sum(1 for p in pixels if p < 250)
+    return nonwhite / len(pixels)
+
+
+def ocr_page(image: Image.Image, ocr_engine=None) -> dict:
+    engine = ocr_engine or _pytesseract()
+    results: list[Tuple[int, str, int, int]] = []
+    for angle in (0, 90, 180, 270):
+        rotated = image.rotate(angle, expand=True)
+        rotated.info["rotation"] = angle
+        try:
+            text = engine.image_to_string(rotated)
+        except Exception:
+            text = ""
+        char_count = len(text)
+        word_count = len(text.split())
+        results.append((angle, text, char_count, word_count))
+    results.sort(key=lambda x: x[2], reverse=True)
+    best = results[0]
+    second = results[1] if len(results) > 1 else (0, "", 0, 0)
+    if best[2] >= 60 or (second[2] == 0 and best[2] > 0) or best[2] >= second[2] * 1.3:
+        chosen = best
+    else:
+        chosen = results[0]
+    ink = _ink_coverage(image)
+    is_blank = chosen[2] < 25 and chosen[3] < 8 and ink < 0.005
+    return {
+        "rotation": chosen[0],
+        "text": chosen[1],
+        "char_count": chosen[2],
+        "word_count": chosen[3],
+        "ink": ink,
+        "is_blank": is_blank,
+    }
+
+
+def process_document_images(
+    document: Document, images: Iterable[Image.Image], ocr_engine=None
+) -> None:
+    texts: list[str] = []
+    kept = 0
+    removed_pages: list[int] = []
+    for idx, img in enumerate(images, start=1):
+        result = ocr_page(img, ocr_engine=ocr_engine)
+        if result["is_blank"]:
+            removed_pages.append(idx)
+            Note.objects.create(document=document, note=f"removed blank page {idx}")
+            continue
+        kept += 1
+        texts.append(result["text"])
+        if result["rotation"] != 0:
+            Note.objects.create(
+                document=document,
+                note=f"auto-rotated page {idx}: {result['rotation']}°",
+            )
+    document.page_count = kept
+    document.content = "\n".join(texts)
+    document.save(update_fields=["page_count", "content"])
+    if kept == 0:
+        tag, _ = Tag.objects.get_or_create(name=BLANK_DOCUMENT_TAG)
+        document.tags.add(tag)
+    # Notes already recorded for removed pages

--- a/src/documents/utils/vendor_guard.py
+++ b/src/documents/utils/vendor_guard.py
@@ -1,7 +1,7 @@
 import re
 
 from dateutil import parser
-from rapidfuzz import fuzz
+from .vendor_match import _load_vendor_map
 
 BLOCKED_NAMES_RAW = {
     "private",
@@ -23,10 +23,7 @@ def normalize_name(value: str | None) -> str:
     if not value:
         return ""
     value = value.lower().strip()
-    value = re.sub(r"[_\-,:]", " ", value)
-    # remove periods not between letters or numbers
-    value = re.sub(r"(?<![\w])\.(?![\w])", " ", value)
-    value = re.sub(r"(?<=\s)\.(?=\w)|(?<=\w)\.(?=\s)|(?<=\w)\.(?=$)", " ", value)
+    value = re.sub(r"[_.\-,:]+", " ", value)
     value = re.sub(r"\s+", " ", value)
     return value
 
@@ -62,12 +59,13 @@ def normalize_invoice_date(value: str | None) -> str | None:
 
 def match_correspondent_by_name(name: str, correspondents) -> list:
     norm = normalize_name(name)
-    matches = []
+    vendor_map = _load_vendor_map()
+    mapping: dict[str, list] = {}
     for corr in correspondents:
-        corr_norm = normalize_name(corr.name)
-        if norm == corr_norm:
-            return [corr]
-        score = fuzz.ratio(norm, corr_norm) / 100.0
-        if score >= 0.86:
-            matches.append(corr)
-    return matches
+        names = [corr.name]
+        if corr.name in vendor_map:
+            names.extend(vendor_map[corr.name])
+        for n in names:
+            key = normalize_name(n)
+            mapping.setdefault(key, []).append(corr)
+    return mapping.get(norm, [])

--- a/src/paperless_mail/mail.py
+++ b/src/paperless_mail/mail.py
@@ -37,6 +37,10 @@ from documents.data_models import DocumentMetadataOverrides
 from documents.data_models import DocumentSource
 from documents.loggers import LoggingMixin
 from documents.models import Correspondent
+from documents.models import Tag
+from documents.utils.vendor_guard import match_correspondent_by_name
+
+NEEDS_VENDOR_TAG = "needs-vendor"
 from documents.parsers import is_mime_type_supported
 from documents.tasks import consume_file
 from paperless_mail.models import MailAccount
@@ -466,12 +470,17 @@ class MailAccountHandler(LoggingMixin):
         else:
             self.log.debug(f"Skipping mail preprocessor {preprocessor_type.NAME}")
 
-    def _correspondent_from_name(self, name: str) -> Correspondent | None:
+    def _correspondent_from_name(self, name: str) -> tuple[Correspondent | None, int | None]:
         try:
-            return Correspondent.objects.get_or_create(name=name)[0]
+            matches = match_correspondent_by_name(name, Correspondent.objects.all())
+            if len(matches) == 1:
+                return matches[0], None
+            tag, _ = Tag.objects.get_or_create(name=NEEDS_VENDOR_TAG)
+            self.log.info(f"Blocked correspondent creation: {name}")
+            return None, tag.id
         except DatabaseError as e:
             self.log.error(f"Error while retrieving correspondent {name}: {e}")
-            return None
+            return None, None
 
     def _get_title(
         self,
@@ -497,25 +506,20 @@ class MailAccountHandler(LoggingMixin):
         self,
         message: MailMessage,
         rule: MailRule,
-    ) -> Correspondent | None:
+    ) -> tuple[Correspondent | None, int | None]:
         c_from = rule.assign_correspondent_from
-
         if c_from == MailRule.CorrespondentSource.FROM_NOTHING:
-            return None
-
+            return None, None
         elif c_from == MailRule.CorrespondentSource.FROM_EMAIL:
             return self._correspondent_from_name(message.from_)
-
         elif c_from == MailRule.CorrespondentSource.FROM_NAME:
             from_values = message.from_values
             if from_values is not None and len(from_values.name) > 0:
                 return self._correspondent_from_name(from_values.name)
             else:
                 return self._correspondent_from_name(message.from_)
-
         elif c_from == MailRule.CorrespondentSource.FROM_CUSTOM:
-            return rule.assign_correspondent
-
+            return rule.assign_correspondent, None
         else:
             raise NotImplementedError(
                 "Unknown correspondent selector",
@@ -801,7 +805,11 @@ class MailAccountHandler(LoggingMixin):
                 )
                 continue
 
-            correspondent = self._get_correspondent(message, rule)
+            correspondent, vendor_tag = self._get_correspondent(message, rule)
+
+            tag_ids_local = list(tag_ids)
+            if vendor_tag and vendor_tag not in tag_ids_local:
+                tag_ids_local.append(vendor_tag)
 
             title = self._get_title(message, att, rule)
 
@@ -844,7 +852,7 @@ class MailAccountHandler(LoggingMixin):
                     filename=pathvalidate.sanitize_filename(att.filename),
                     correspondent_id=correspondent.id if correspondent else None,
                     document_type_id=doc_type.id if doc_type else None,
-                    tag_ids=tag_ids,
+                    tag_ids=tag_ids_local,
                     owner_id=(
                         rule.owner.id
                         if (rule.assign_owner_from_rule and rule.owner)
@@ -928,7 +936,11 @@ class MailAccountHandler(LoggingMixin):
 
             f.write(message.obj.as_bytes())
 
-        correspondent = self._get_correspondent(message, rule)
+        correspondent, vendor_tag = self._get_correspondent(message, rule)
+
+        tag_ids_local = list(tag_ids)
+        if vendor_tag and vendor_tag not in tag_ids_local:
+            tag_ids_local.append(vendor_tag)
 
         self.log.info(
             f"Rule {rule}: "
@@ -946,7 +958,7 @@ class MailAccountHandler(LoggingMixin):
             filename=pathvalidate.sanitize_filename(f"{message.subject}.eml"),
             correspondent_id=correspondent.id if correspondent else None,
             document_type_id=doc_type.id if doc_type else None,
-            tag_ids=tag_ids,
+            tag_ids=tag_ids_local,
             owner_id=rule.owner.id if rule.owner else None,
         )
 


### PR DESCRIPTION
## Summary
- ensure correspondents are matched only against existing records and tag unknown names
- auto-rotate pages during OCR, skip blank pages, and log rotations/removals
- add tests covering correspondent matching, page rotation and blank-page filtering

## Testing
- `pytest src/documents/tests/test_vendor_guardrails.py::test_match_only_correspondent_no_creation -q` *(fails: No module named 'django_extensions')*
- `pytest src/documents/tests/test_ocr_processing.py::test_rotation_selects_best -q` *(fails: No module named 'django_extensions')*

------
https://chatgpt.com/codex/tasks/task_e_68c5d930dfc883308d16e9735b9a0a7d