### PR TITLE
feat: add split upload toggle

### DIFF
--- a/src-ui/src/app/components/dashboard/widgets/upload-file-widget/upload-file-widget.component.html
+++ b/src-ui/src/app/components/dashboard/widgets/upload-file-widget/upload-file-widget.component.html
@@ -1,6 +1,18 @@
 <pngx-widget-frame *pngxIfPermissions="{ action: PermissionAction.Add, type: PermissionType.Document }" [cardless]="true">
   <div content tourAnchor="tour.upload-widget">
     <form class="justify-content-center d-flex flex-column align-items-center">
+      <div class="form-check form-switch align-self-end mb-2">
+          <input
+            class="form-check-input"
+            type="checkbox"
+            [(ngModel)]="splitOnUpload"
+            id="splitOnUpload"
+            name="splitOnUpload"
+          />
+        <label class="form-check-label" for="splitOnUpload" i18n>
+          Split PDFs on upload
+        </label>
+      </div>
       <button type="button" class="btn btn-outline-dark bg-light shadow-sm w-100 h-100 pt-3 pb-3" (click)="fileUpload.click()">
         <i-bs class="text-primary" name="plus-circle"></i-bs>&nbsp;
         <span class="text-primary" i18n>Upload documents</span>

--- a/src-ui/src/app/components/dashboard/widgets/upload-file-widget/upload-file-widget.component.html
+++ b/src-ui/src/app/components/dashboard/widgets/upload-file-widget/upload-file-widget.component.html
@@ -6,6 +6,7 @@
             class="form-check-input"
             type="checkbox"
             [(ngModel)]="splitOnUpload"
+            (ngModelChange)="onSplitOnUploadChange()"
             id="splitOnUpload"
             name="splitOnUpload"
           />

--- a/src-ui/src/app/components/dashboard/widgets/upload-file-widget/upload-file-widget.component.spec.ts
+++ b/src-ui/src/app/components/dashboard/widgets/upload-file-widget/upload-file-widget.component.spec.ts
@@ -13,12 +13,14 @@ import { routes } from 'src/app/app-routing.module'
 import { PermissionsGuard } from 'src/app/guards/permissions.guard'
 import { PermissionsService } from 'src/app/services/permissions.service'
 import { UploadDocumentsService } from 'src/app/services/upload-documents.service'
+import { ConfigService } from 'src/app/services/config.service'
 import {
   FileStatus,
   FileStatusPhase,
   WebsocketStatusService,
 } from 'src/app/services/websocket-status.service'
 import { UploadFileWidgetComponent } from './upload-file-widget.component'
+import { of } from 'rxjs'
 
 const FAILED_STATUSES = [new FileStatus()]
 const WORKING_STATUSES = [new FileStatus(), new FileStatus()]
@@ -61,6 +63,10 @@ describe('UploadFileWidgetComponent', () => {
         },
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting(),
+        {
+          provide: ConfigService,
+          useValue: { getConfig: () => of({ split_pdf_on_upload: false }) },
+        },
       ],
     }).compileComponents()
 
@@ -73,7 +79,7 @@ describe('UploadFileWidgetComponent', () => {
   })
 
   it('should support browse files', () => {
-    const fileInput = fixture.debugElement.query(By.css('input'))
+    const fileInput = fixture.debugElement.query(By.css('input[type="file"]'))
     const clickSpy = jest.spyOn(fileInput.nativeElement, 'click')
     fixture.debugElement
       .query(By.css('button'))
@@ -87,7 +93,7 @@ describe('UploadFileWidgetComponent', () => {
       [new Blob(['testing'], { type: 'application/pdf' })],
       'file.pdf'
     )
-    const fileInput = fixture.debugElement.query(By.css('input'))
+    const fileInput = fixture.debugElement.query(By.css('input[type="file"]'))
     jest.spyOn(fileInput.nativeElement, 'files', 'get').mockReturnValue({
       item: () => file,
       length: 1,

--- a/src-ui/src/app/components/dashboard/widgets/upload-file-widget/upload-file-widget.component.ts
+++ b/src-ui/src/app/components/dashboard/widgets/upload-file-widget/upload-file-widget.component.ts
@@ -53,9 +53,14 @@ export class UploadFileWidgetComponent
   @ViewChildren(NgbAlert) alerts: QueryList<NgbAlert>
 
   ngOnInit() {
-    this.configService
-      .getConfig()
-      .subscribe((c) => (this.splitOnUpload = !!c.split_pdf_on_upload))
+    this.configService.getConfig().subscribe((c) => {
+      this.splitOnUpload = !!c.split_pdf_on_upload
+      this.uploadDocumentsService.setSplitPdfOnUpload(this.splitOnUpload)
+    })
+  }
+
+  onSplitOnUploadChange() {
+    this.uploadDocumentsService.setSplitPdfOnUpload(this.splitOnUpload)
   }
 
   getStatus() {
@@ -147,11 +152,10 @@ export class UploadFileWidgetComponent
   public onFileSelected(event: Event) {
     const files = (event.target as HTMLInputElement).files
     for (let i = 0; i < files?.length; i++) {
-        const file = files.item(i)
-        file &&
-          this.uploadDocumentsService.uploadFile(file, this.splitOnUpload)
-      }
+      const file = files.item(i)
+      file && this.uploadDocumentsService.uploadFile(file)
     }
+  }
 
   get slimSidebarEnabled(): boolean {
     return this.settingsService.get(SETTINGS_KEYS.SLIM_SIDEBAR)

--- a/src-ui/src/app/data/paperless-config.ts
+++ b/src-ui/src/app/data/paperless-config.ts
@@ -182,6 +182,13 @@ export const PaperlessConfigOptions: ConfigOption[] = [
     category: ConfigCategory.General,
   },
   {
+    key: 'split_pdf_on_upload',
+    title: $localize`Split PDFs on upload`,
+    type: ConfigOptionType.Boolean,
+    config_key: 'PAPERLESS_CONSUMER_SPLIT_PDF_ON_UPLOAD',
+    category: ConfigCategory.General,
+  },
+  {
     key: 'barcodes_enabled',
     title: $localize`Enable Barcodes`,
     type: ConfigOptionType.Boolean,
@@ -276,6 +283,7 @@ export interface PaperlessConfig extends ObjectWithId {
   user_args: object
   app_logo: string
   app_title: string
+  split_pdf_on_upload: boolean
   barcodes_enabled: boolean
   barcode_enable_tiff_support: boolean
   barcode_string: string

--- a/src-ui/src/app/services/upload-documents.service.spec.ts
+++ b/src-ui/src/app/services/upload-documents.service.spec.ts
@@ -56,7 +56,22 @@ describe('UploadDocumentsService', () => {
       `${environment.apiBaseUrl}documents/post_document/`
     )
     expect(req[0].request.method).toEqual('POST')
+    expect(req[0].request.body.get('split_pdf')).toEqual('false')
 
+    req[0].flush('123-456')
+  })
+
+  it('passes split preference', () => {
+    const file = new File(
+      [new Blob(['testing'], { type: 'application/pdf' })],
+      'file.pdf'
+    )
+    uploadDocumentsService.setSplitPdfOnUpload(true)
+    uploadDocumentsService.uploadFile(file)
+    const req = httpTestingController.match(
+      `${environment.apiBaseUrl}documents/post_document/`
+    )
+    expect(req[0].request.body.get('split_pdf')).toEqual('true')
     req[0].flush('123-456')
   })
 

--- a/src-ui/src/app/services/upload-documents.service.spec.ts
+++ b/src-ui/src/app/services/upload-documents.service.spec.ts
@@ -14,6 +14,8 @@ import {
   FileStatusPhase,
   WebsocketStatusService,
 } from './websocket-status.service'
+import { ConfigService } from './config.service'
+import { of } from 'rxjs'
 
 describe('UploadDocumentsService', () => {
   let httpTestingController: HttpTestingController
@@ -26,6 +28,10 @@ describe('UploadDocumentsService', () => {
       providers: [
         UploadDocumentsService,
         WebsocketStatusService,
+        {
+          provide: ConfigService,
+          useValue: { getConfig: () => of({ split_pdf_on_upload: false }) },
+        },
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting(),
       ],

--- a/src-ui/src/app/services/upload-documents.service.ts
+++ b/src-ui/src/app/services/upload-documents.service.ts
@@ -16,10 +16,13 @@ export class UploadDocumentsService {
 
   private uploadSubscriptions: Array<Subscription> = []
 
-  public uploadFile(file: File) {
+  public uploadFile(file: File, splitPdfOnUpload = false) {
     let formData = new FormData()
     formData.append('document', file, file.name)
     formData.append('from_webui', 'true')
+    if (splitPdfOnUpload) {
+      formData.append('split_pdf', 'true')
+    }
     let status = this.websocketStatusService.newFileUpload(file.name)
 
     status.message = $localize`Connecting...`

--- a/src-ui/src/app/services/upload-documents.service.ts
+++ b/src-ui/src/app/services/upload-documents.service.ts
@@ -33,9 +33,7 @@ export class UploadDocumentsService {
     let formData = new FormData()
     formData.append('document', file, file.name)
     formData.append('from_webui', 'true')
-    if (splitPdfOnUpload) {
-      formData.append('split_pdf', 'true')
-    }
+    formData.append('split_pdf', splitPdfOnUpload ? 'true' : 'false')
     let status = this.websocketStatusService.newFileUpload(file.name)
 
     status.message = $localize`Connecting...`

--- a/src-ui/src/app/services/upload-documents.service.ts
+++ b/src-ui/src/app/services/upload-documents.service.ts
@@ -1,6 +1,7 @@
 import { HttpEventType } from '@angular/common/http'
 import { Injectable, inject } from '@angular/core'
 import { Subscription } from 'rxjs'
+import { ConfigService } from './config.service'
 import { DocumentService } from './rest/document.service'
 import {
   FileStatusPhase,
@@ -13,10 +14,22 @@ import {
 export class UploadDocumentsService {
   private documentService = inject(DocumentService)
   private websocketStatusService = inject(WebsocketStatusService)
+  private configService = inject(ConfigService)
 
   private uploadSubscriptions: Array<Subscription> = []
+  private splitPdfOnUpload = false
 
-  public uploadFile(file: File, splitPdfOnUpload = false) {
+  constructor() {
+    this.configService
+      .getConfig()
+      .subscribe((c) => (this.splitPdfOnUpload = !!c.split_pdf_on_upload))
+  }
+
+  public setSplitPdfOnUpload(split: boolean) {
+    this.splitPdfOnUpload = split
+  }
+
+  public uploadFile(file: File, splitPdfOnUpload = this.splitPdfOnUpload) {
     let formData = new FormData()
     formData.append('document', file, file.name)
     formData.append('from_webui', 'true')

--- a/src/documents/data_models.py
+++ b/src/documents/data_models.py
@@ -30,6 +30,7 @@ class DocumentMetadataOverrides:
     change_users: list[int] | None = None
     change_groups: list[int] | None = None
     custom_fields: dict | None = None
+    split_pdf_on_upload: bool | None = None
 
     def update(self, other: "DocumentMetadataOverrides") -> "DocumentMetadataOverrides":
         """
@@ -49,6 +50,8 @@ class DocumentMetadataOverrides:
             self.storage_path_id = other.storage_path_id
         if other.owner_id is not None:
             self.owner_id = other.owner_id
+        if other.split_pdf_on_upload is not None:
+            self.split_pdf_on_upload = other.split_pdf_on_upload
 
         # merge
         if self.tag_ids is None:

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -1682,6 +1682,12 @@ class PostDocumentSerializer(serializers.Serializer):
         required=False,
     )
 
+    split_pdf = serializers.BooleanField(
+        label="Split PDF on upload",
+        write_only=True,
+        required=False,
+    )
+
     def validate_document(self, document):
         document_data = document.file.read()
         mime_type = magic.from_buffer(document_data, mime=True)

--- a/src/documents/split_pages.py
+++ b/src/documents/split_pages.py
@@ -23,10 +23,12 @@ class SplitPagesPlugin(ConsumeTaskPlugin):
 
     @property
     def able_to_run(self) -> bool:
-        return (
-            settings.CONSUMER_SPLIT_PDF_ON_UPLOAD
-            and self.input_doc.mime_type == "application/pdf"
+        enabled = (
+            self.metadata.split_pdf_on_upload
+            if self.metadata.split_pdf_on_upload is not None
+            else settings.CONSUMER_SPLIT_PDF_ON_UPLOAD
         )
+        return enabled and self.input_doc.mime_type == "application/pdf"
 
     def setup(self) -> None:
         self.temp_dir = tempfile.TemporaryDirectory(

--- a/src/documents/tests/test_split_pages.py
+++ b/src/documents/tests/test_split_pages.py
@@ -41,3 +41,25 @@ class TestSplitPagesPlugin(
         self.assertEqual(result, "Page splitting complete!")
         self.assertEqual(delay_mock.call_count, 2)
         self.assertIsNotFile(temp_copy)
+
+    @override_settings(CONSUMER_SPLIT_PDF_ON_UPLOAD=False)
+    def test_split_with_override(self):
+        test_file = self.SAMPLE_DIR / "double-sided-even.pdf"
+        temp_copy = self.dirs.scratch_dir / test_file.name
+        shutil.copy(test_file, temp_copy)
+
+        with (
+            mock.patch("documents.tasks.ProgressManager", DummyProgressManager),
+            mock.patch("documents.tasks.consume_file.delay") as delay_mock,
+        ):
+            result = tasks.consume_file(
+                ConsumableDocument(
+                    source=DocumentSource.ConsumeFolder,
+                    original_file=temp_copy,
+                ),
+                DocumentMetadataOverrides(split_pdf_on_upload=True),
+            )
+
+        self.assertEqual(result, "Page splitting complete!")
+        self.assertEqual(delay_mock.call_count, 2)
+        self.assertIsNotFile(temp_copy)

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -1499,6 +1499,7 @@ class PostDocumentView(GenericAPIView):
         archive_serial_number = serializer.validated_data.get("archive_serial_number")
         custom_field_ids = serializer.validated_data.get("custom_fields")
         from_webui = serializer.validated_data.get("from_webui")
+        split_pdf = serializer.validated_data.get("split_pdf")
 
         t = int(mktime(datetime.now().timetuple()))
 
@@ -1526,6 +1527,7 @@ class PostDocumentView(GenericAPIView):
             created=created,
             asn=archive_serial_number,
             owner_id=request.user.id,
+            split_pdf_on_upload=split_pdf,
             # TODO: set values
             custom_fields={cf_id: None for cf_id in custom_field_ids}
             if custom_field_ids

--- a/src/paperless/config.py
+++ b/src/paperless/config.py
@@ -163,9 +163,15 @@ class GeneralConfig(BaseConfig):
 
     app_title: str = dataclasses.field(init=False)
     app_logo: str = dataclasses.field(init=False)
+    split_pdf_on_upload: bool = dataclasses.field(init=False)
 
     def __post_init__(self) -> None:
         app_config = self._get_config_instance()
 
         self.app_title = app_config.app_title or None
         self.app_logo = app_config.app_logo.url if app_config.app_logo else None
+        self.split_pdf_on_upload = (
+            app_config.split_pdf_on_upload
+            if app_config.split_pdf_on_upload is not None
+            else settings.CONSUMER_SPLIT_PDF_ON_UPLOAD
+        )

--- a/src/paperless/migrations/0005_applicationconfiguration_split_pdf_on_upload.py
+++ b/src/paperless/migrations/0005_applicationconfiguration_split_pdf_on_upload.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("paperless", "0004_applicationconfiguration_barcode_asn_prefix_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="applicationconfiguration",
+            name="split_pdf_on_upload",
+            field=models.BooleanField(null=True, verbose_name="Split PDFs on upload"),
+        ),
+    ]

--- a/src/paperless/models.py
+++ b/src/paperless/models.py
@@ -188,6 +188,12 @@ class ApplicationConfiguration(AbstractSingletonModel):
         upload_to="logo/",
     )
 
+    # PAPERLESS_CONSUMER_SPLIT_PDF_ON_UPLOAD
+    split_pdf_on_upload = models.BooleanField(
+        verbose_name=_("Split PDFs on upload"),
+        null=True,
+    )
+
     """
     Settings for the barcode scanner
     """


### PR DESCRIPTION
## Summary
- add UI toggle to split PDFs on upload
- allow per-upload and configurable default splitting

## Testing
- `uv run pytest src/documents/tests/test_split_pages.py` *(fails: failed to find libmagic)*
- `cd src-ui && pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68c65aaed154833083a61529dc6794c3