### PR TITLE
feat: add split header support and blank-page skip

### DIFF
--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -96,6 +96,7 @@ class ConsumerStatusShortMessage(str, Enum):
     SAVE_DOCUMENT = "save_document"
     FINISHED = "finished"
     FAILED = "failed"
+    BLANK_PAGE = "blank_page"
 
 
 class ConsumerPluginMixin:
@@ -429,6 +430,23 @@ class ConsumerPlugin(
                 date = parse_date(self.filename, text)
             archive_path = document_parser.get_archive_path()
             page_count = document_parser.get_page_count(self.working_copy, mime_type)
+
+            if not text or len(text.strip()) < 10:
+                document_parser.cleanup()
+                if tempdir:
+                    tempdir.cleanup()
+                self._send_progress(
+                    100,
+                    100,
+                    ProgressStatusOptions.SUCCESS,
+                    ConsumerStatusShortMessage.BLANK_PAGE,
+                )
+                self.log.info(
+                    f"Skipping {self.filename}: blank after OCR",
+                )
+                self.input_doc.original_file.unlink()
+                self.working_copy.unlink()
+                return f"Blank document {self.filename} skipped"
 
         except ParseError as e:
             document_parser.cleanup()

--- a/src/documents/tests/test_api_documents.py
+++ b/src/documents/tests/test_api_documents.py
@@ -1161,6 +1161,25 @@ class TestDocumentApi(DirectoriesMixin, DocumentConsumeDelayMixin, APITestCase):
         self.assertIsNone(overrides.document_type_id)
         self.assertIsNone(overrides.tag_ids)
 
+    def test_upload_split_header(self):
+        self.consume_file_mock.return_value = celery.result.AsyncResult(
+            id=str(uuid.uuid4()),
+        )
+
+        with (Path(__file__).parent / "samples" / "simple.pdf").open("rb") as f:
+            response = self.client.post(
+                "/api/documents/post_document/",
+                {"document": f},
+                HTTP_X_SPLIT_PAGES="1",
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.consume_file_mock.assert_called_once()
+
+        input_doc, _ = self.get_last_consume_delay_call_args()
+        self.assertEqual(Path(input_doc.original_file).name, "simple_page_1.pdf")
+
     def test_create_wrong_endpoint(self):
         response = self.client.post(
             "/api/documents/",

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -1501,6 +1501,10 @@ class PostDocumentView(GenericAPIView):
         custom_field_ids = serializer.validated_data.get("custom_fields")
         from_webui = serializer.validated_data.get("from_webui")
         split_pdf = serializer.validated_data.get("split_pdf")
+        if split_pdf is None:
+            header_split = request.headers.get("X-Split-Pages")
+            if header_split is not None:
+                split_pdf = header_split == "1"
 
         t = int(mktime(datetime.now().timetuple()))
 
@@ -1526,7 +1530,9 @@ class PostDocumentView(GenericAPIView):
                         new_pdf.save(split_path)
                     os.utime(split_path, times=(t, t))
                     page_doc = ConsumableDocument(
-                        source=DocumentSource.WebUI if from_webui else DocumentSource.ApiUpload,
+                        source=DocumentSource.WebUI
+                        if from_webui
+                        else DocumentSource.ApiUpload,
                         original_file=split_path,
                     )
                     page_overrides = DocumentMetadataOverrides(


### PR DESCRIPTION
## Summary
- allow API uploads to trigger page splitting using `X-Split-Pages` header
- skip ingesting pages with no OCR text to avoid blank documents
- test split header upload

## Testing
- `PYTEST_ADDOPTS='' pytest src/documents/tests/test_api_documents.py::TestDocumentApi::test_upload -q` *(fails: Error 111 connecting to localhost:6379. Connection refused)*


------
https://chatgpt.com/codex/tasks/task_e_68c5f87a2a5c83309755d1d102b8e13f