### PR TITLE
feat(ui): persist split toggle across reloads

### DIFF
--- a/src-ui/src/app/components/dashboard/widgets/upload-file-widget/upload-file-widget.component.html
+++ b/src-ui/src/app/components/dashboard/widgets/upload-file-widget/upload-file-widget.component.html
@@ -1,6 +1,17 @@
 <pngx-widget-frame *pngxIfPermissions="{ action: PermissionAction.Add, type: PermissionType.Document }" [cardless]="true">
   <div content tourAnchor="tour.upload-widget">
     <form class="justify-content-center d-flex flex-column align-items-center">
+      <div class="form-check form-switch align-self-end mb-2">
+        <input
+          class="form-check-input"
+          type="checkbox"
+          id="splitToggle"
+          name="splitToggle"
+          [(ngModel)]="uploadDocumentsService.splitEnabled"
+          [ngModelOptions]="{standalone: true}"
+        />
+        <label class="form-check-label" for="splitToggle" i18n>Split</label>
+      </div>
       <button type="button" class="btn btn-outline-dark bg-light shadow-sm w-100 h-100 pt-3 pb-3" (click)="fileUpload.click()">
         <i-bs class="text-primary" name="plus-circle"></i-bs>&nbsp;
         <span class="text-primary" i18n>Upload documents</span>

--- a/src-ui/src/app/components/dashboard/widgets/upload-file-widget/upload-file-widget.component.spec.ts
+++ b/src-ui/src/app/components/dashboard/widgets/upload-file-widget/upload-file-widget.component.spec.ts
@@ -73,7 +73,7 @@ describe('UploadFileWidgetComponent', () => {
   })
 
   it('should support browse files', () => {
-    const fileInput = fixture.debugElement.query(By.css('input'))
+    const fileInput = fixture.debugElement.query(By.css('input[type="file"]'))
     const clickSpy = jest.spyOn(fileInput.nativeElement, 'click')
     fixture.debugElement
       .query(By.css('button'))
@@ -87,7 +87,7 @@ describe('UploadFileWidgetComponent', () => {
       [new Blob(['testing'], { type: 'application/pdf' })],
       'file.pdf'
     )
-    const fileInput = fixture.debugElement.query(By.css('input'))
+    const fileInput = fixture.debugElement.query(By.css('input[type="file"]'))
     jest.spyOn(fileInput.nativeElement, 'files', 'get').mockReturnValue({
       item: () => file,
       length: 1,

--- a/src-ui/src/app/components/dashboard/widgets/upload-file-widget/upload-file-widget.component.ts
+++ b/src-ui/src/app/components/dashboard/widgets/upload-file-widget/upload-file-widget.component.ts
@@ -1,5 +1,6 @@
 import { NgClass, NgTemplateOutlet } from '@angular/common'
 import { Component, QueryList, ViewChildren, inject } from '@angular/core'
+import { FormsModule } from '@angular/forms'
 import { RouterModule } from '@angular/router'
 import {
   NgbAlert,
@@ -29,6 +30,7 @@ import { WidgetFrameComponent } from '../widget-frame/widget-frame.component'
     IfPermissionsDirective,
     NgClass,
     NgTemplateOutlet,
+    FormsModule,
     RouterModule,
     NgbAlertModule,
     NgbProgressbarModule,
@@ -38,7 +40,7 @@ import { WidgetFrameComponent } from '../widget-frame/widget-frame.component'
 })
 export class UploadFileWidgetComponent extends ComponentWithPermissions {
   private websocketStatusService = inject(WebsocketStatusService)
-  private uploadDocumentsService = inject(UploadDocumentsService)
+  public uploadDocumentsService = inject(UploadDocumentsService)
   settingsService = inject(SettingsService)
 
   @ViewChildren(NgbAlert) alerts: QueryList<NgbAlert>

--- a/src-ui/src/app/services/rest/document.service.spec.ts
+++ b/src-ui/src/app/services/rest/document.service.spec.ts
@@ -150,11 +150,12 @@ describe(`DocumentService`, () => {
   })
 
   it('should call appropriate api endpoint for uploading a document', () => {
-    subscription = service.uploadDocument(documents[0]).subscribe()
+    subscription = service.uploadDocument(documents[0], true).subscribe()
     const req = httpTestingController.expectOne(
       `${environment.apiBaseUrl}${endpoint}/post_document/`
     )
     expect(req.request.method).toEqual('POST')
+    expect(req.request.headers.get('X-Split-Pages')).toEqual('1')
   })
 
   it('should call appropriate api endpoint for getting metadata', () => {

--- a/src-ui/src/app/services/rest/document.service.ts
+++ b/src-ui/src/app/services/rest/document.service.ts
@@ -195,11 +195,15 @@ export class DocumentService extends AbstractPaperlessService<Document> {
     return super.patch(o)
   }
 
-  uploadDocument(formData) {
+  uploadDocument(formData, splitPages: boolean = false) {
     return this.http.post(
       this.getResourceUrl(null, 'post_document'),
       formData,
-      { reportProgress: true, observe: 'events' }
+      {
+        reportProgress: true,
+        observe: 'events',
+        headers: { 'X-Split-Pages': splitPages ? '1' : '0' },
+      }
     )
   }
 

--- a/src-ui/src/app/services/upload-documents.service.spec.ts
+++ b/src-ui/src/app/services/upload-documents.service.spec.ts
@@ -45,11 +45,13 @@ describe('UploadDocumentsService', () => {
       [new Blob(['testing'], { type: 'application/pdf' })],
       'file.pdf'
     )
+    uploadDocumentsService.splitEnabled = true
     uploadDocumentsService.uploadFile(file)
     const req = httpTestingController.match(
       `${environment.apiBaseUrl}documents/post_document/`
     )
     expect(req[0].request.method).toEqual('POST')
+    expect(req[0].request.headers.get('X-Split-Pages')).toEqual('1')
 
     req[0].flush('123-456')
   })

--- a/src-ui/src/app/services/upload-documents.service.ts
+++ b/src-ui/src/app/services/upload-documents.service.ts
@@ -16,6 +16,18 @@ export class UploadDocumentsService {
 
   private uploadSubscriptions: Array<Subscription> = []
 
+  private _splitEnabled =
+    localStorage.getItem('paperless.split.enabled') === 'true'
+
+  get splitEnabled(): boolean {
+    return this._splitEnabled
+  }
+
+  set splitEnabled(value: boolean) {
+    this._splitEnabled = value
+    localStorage.setItem('paperless.split.enabled', value ? 'true' : 'false')
+  }
+
   public uploadFile(file: File) {
     let formData = new FormData()
     formData.append('document', file, file.name)
@@ -25,7 +37,7 @@ export class UploadDocumentsService {
     status.message = $localize`Connecting...`
 
     this.uploadSubscriptions[file.name] = this.documentService
-      .uploadDocument(formData)
+      .uploadDocument(formData, this.splitEnabled)
       .subscribe({
         next: (event) => {
           if (event.type == HttpEventType.UploadProgress) {

--- a/src-ui/src/app/services/websocket-status.service.spec.ts
+++ b/src-ui/src/app/services/websocket-status.service.spec.ts
@@ -164,7 +164,7 @@ describe('ConsumerStatusService', () => {
     const task_id = '1234'
     const status = websocketStatusService.newFileUpload('file.pdf')
 
-    documentService.uploadDocument({}).subscribe((event) => {
+    documentService.uploadDocument({}, false).subscribe((event) => {
       if (event.type === HttpEventType.Response) {
         status.taskId = event.body['task_id']
         status.message = $localize`Upload complete, waiting...`


### PR DESCRIPTION
## Summary
- remember Split toggle via localStorage and apply on startup
- include X-Split-Pages header on uploads
- expose split toggle in upload widget

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6649ebbc08330baa7a42ee1811b11