### PR TITLE
feat: add server-side PDF split toggle

### DIFF
--- a/src-ui/src/app/components/dashboard/widgets/upload-file-widget/upload-file-widget.component.ts
+++ b/src-ui/src/app/components/dashboard/widgets/upload-file-widget/upload-file-widget.component.ts
@@ -1,12 +1,19 @@
 import { NgClass, NgTemplateOutlet } from '@angular/common'
-import { Component, OnInit, QueryList, ViewChildren, inject } from '@angular/core'
+import { HttpClient, HttpClientModule } from '@angular/common/http'
+import {
+  Component,
+  OnInit,
+  QueryList,
+  ViewChildren,
+  inject,
+} from '@angular/core'
+import { FormsModule } from '@angular/forms'
 import { RouterModule } from '@angular/router'
 import {
   NgbAlert,
   NgbAlertModule,
   NgbProgressbarModule,
 } from '@ng-bootstrap/ng-bootstrap'
-import { FormsModule } from '@angular/forms'
 import { NgxBootstrapIconsModule } from 'ngx-bootstrap-icons'
 import { TourNgBootstrapModule } from 'ngx-ui-tour-ng-bootstrap'
 import { ComponentWithPermissions } from 'src/app/components/with-permissions/with-permissions.component'
@@ -38,6 +45,7 @@ export const SPLIT_PDF_STORAGE_KEY = 'upload_split_pdf'
     NgxBootstrapIconsModule,
     TourNgBootstrapModule,
     FormsModule,
+    HttpClientModule,
   ],
 })
 export class UploadFileWidgetComponent
@@ -47,6 +55,7 @@ export class UploadFileWidgetComponent
   private websocketStatusService = inject(WebsocketStatusService)
   private uploadDocumentsService = inject(UploadDocumentsService)
   settingsService = inject(SettingsService)
+  private http = inject(HttpClient)
 
   splitPdf = false
 
@@ -61,10 +70,19 @@ export class UploadFileWidgetComponent
     if (storedValue !== null) {
       this.splitPdf = storedValue === 'true'
     }
+    this.http
+      .get<{ value: boolean }>('/api/settings/split_pdf_enabled/')
+      .subscribe((resp) => {
+        this.splitPdf = resp.value
+        localStorage.setItem(SPLIT_PDF_STORAGE_KEY, String(this.splitPdf))
+      })
   }
 
   onSplitPdfChange() {
     localStorage.setItem(SPLIT_PDF_STORAGE_KEY, String(this.splitPdf))
+    this.http
+      .put('/api/settings/split_pdf_enabled/', { value: this.splitPdf })
+      .subscribe()
   }
 
   getStatusSummary() {

--- a/src/documents/management/commands/document_consumer.py
+++ b/src/documents/management/commands/document_consumer.py
@@ -1,5 +1,9 @@
 import logging
 import os
+import re
+import shutil
+import subprocess
+import tempfile
 from concurrent.futures import ThreadPoolExecutor
 from fnmatch import filter
 from pathlib import Path
@@ -13,6 +17,8 @@ from django import db
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.core.management.base import CommandError
+from filelock import FileLock
+from pikepdf import Pdf
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers.polling import PollingObserver
 
@@ -22,6 +28,7 @@ from documents.data_models import DocumentSource
 from documents.models import Tag
 from documents.parsers import is_file_ext_supported
 from documents.tasks import consume_file
+from paperless.config import is_split_enabled
 
 try:
     from inotifyrecursive import INotify
@@ -122,6 +129,68 @@ def _consume(filepath: Path) -> None:
         logger.exception("Error creating tags from path")
 
     try:
+        if (
+            is_split_enabled()
+            and filepath.suffix.lower() == ".pdf"
+            and not re.search(r"__page-\d{5}\.pdf$", filepath.name)
+        ):
+            try:
+                with Pdf.open(filepath) as pdf:
+                    page_count = len(pdf.pages)
+            except Exception:
+                page_count = 1
+            if page_count > 1:
+                lock = FileLock(str(filepath) + ".lock")
+                with lock:
+                    with tempfile.TemporaryDirectory(dir=filepath.parent) as tmp_dir:
+                        tmp_path = Path(tmp_dir)
+                        subprocess.run(
+                            [
+                                "qpdf",
+                                "--split-pages",
+                                str(filepath),
+                                str(tmp_path / "page-%05d.pdf"),
+                            ],
+                            check=True,
+                        )
+                        for page_file in sorted(tmp_path.glob("page-*.pdf")):
+                            idx = int(page_file.stem.split("-")[-1])
+                            split_name = f"{filepath.stem}__page-{idx:05}.pdf"
+                            target = filepath.parent / split_name
+                            shutil.move(str(page_file), target)
+                            try:
+                                subprocess.run(
+                                    [
+                                        "ocrmypdf",
+                                        "--rotate-pages",
+                                        "--rotate-pages-threshold",
+                                        "10",
+                                        "--deskew",
+                                        "--clean",
+                                        "--skip-text",
+                                        str(target),
+                                        str(target),
+                                    ],
+                                    check=True,
+                                )
+                            except Exception:
+                                logger.exception("Error during OCR on split page")
+                            consume_file.delay(
+                                ConsumableDocument(
+                                    source=DocumentSource.ConsumeFolder,
+                                    original_file=target,
+                                ),
+                                DocumentMetadataOverrides(tag_ids=tag_ids),
+                            )
+                    try:
+                        settings.ORIGINALS_DIR.mkdir(parents=True, exist_ok=True)
+                        shutil.move(
+                            str(filepath),
+                            settings.ORIGINALS_DIR / filepath.name,
+                        )
+                    except Exception:
+                        logger.exception("Error moving original after split")
+                return
         logger.info(f"Adding {filepath} to the task queue.")
         consume_file.delay(
             ConsumableDocument(

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -1744,6 +1744,10 @@ class PostDocumentSerializer(serializers.Serializer):
             return created.date()
 
 
+class SplitPdfSettingSerializer(serializers.Serializer):
+    value = serializers.BooleanField()
+
+
 class BulkDownloadSerializer(DocumentListSerializer):
     content = serializers.ChoiceField(
         choices=["archive", "originals", "both"],

--- a/src/documents/tests/test_api_app_config.py
+++ b/src/documents/tests/test_api_app_config.py
@@ -54,6 +54,7 @@ class TestApiAppConfig(DirectoriesMixin, APITestCase):
                 "user_args": None,
                 "app_title": None,
                 "app_logo": None,
+                "split_pdf_enabled": False,
                 "barcodes_enabled": None,
                 "barcode_enable_tiff_support": None,
                 "barcode_string": None,

--- a/src/documents/tests/test_api_split_pdf_setting.py
+++ b/src/documents/tests/test_api_split_pdf_setting.py
@@ -1,0 +1,25 @@
+from django.contrib.auth.models import User
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from paperless.models import ApplicationConfiguration
+
+
+class TestSplitPdfSetting(APITestCase):
+    ENDPOINT = "/api/settings/split_pdf_enabled/"
+
+    def setUp(self) -> None:
+        user = User.objects.create_superuser(username="admin")
+        self.client.force_authenticate(user=user)
+
+    def test_get_default(self):
+        response = self.client.get(self.ENDPOINT, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, {"value": False})
+
+    def test_set_value(self):
+        response = self.client.put(self.ENDPOINT, {"value": True}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["value"], True)
+        config = ApplicationConfiguration.objects.first()
+        self.assertTrue(config.split_pdf_enabled)

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -15,7 +15,6 @@ from urllib.parse import urlparse
 import httpx
 import magic
 import pathvalidate
-from pikepdf import Pdf
 from celery import states
 from django.conf import settings
 from django.contrib.auth.models import Group
@@ -59,6 +58,7 @@ from drf_spectacular.utils import extend_schema_view
 from drf_spectacular.utils import inline_serializer
 from langdetect import detect
 from packaging import version as packaging_version
+from pikepdf import Pdf
 from redis import Redis
 from rest_framework import parsers
 from rest_framework import serializers
@@ -154,6 +154,7 @@ from documents.serialisers import RunTaskViewSerializer
 from documents.serialisers import SavedViewSerializer
 from documents.serialisers import SearchResultSerializer
 from documents.serialisers import ShareLinkSerializer
+from documents.serialisers import SplitPdfSettingSerializer
 from documents.serialisers import StoragePathSerializer
 from documents.serialisers import StoragePathTestSerializer
 from documents.serialisers import TagSerializer
@@ -175,6 +176,7 @@ from documents.utils import get_boolean
 from paperless import version
 from paperless.celery import app as celery_app
 from paperless.config import GeneralConfig
+from paperless.config import is_split_enabled
 from paperless.db import GnuPG
 from paperless.models import ApplicationConfiguration
 from paperless.serialisers import GroupSerializer
@@ -1501,6 +1503,7 @@ class PostDocumentView(GenericAPIView):
         custom_field_ids = serializer.validated_data.get("custom_fields")
         from_webui = serializer.validated_data.get("from_webui")
         split_pdf = serializer.validated_data.get("split_pdf")
+        effective_split = split_pdf or is_split_enabled()
 
         t = int(mktime(datetime.now().timetuple()))
 
@@ -1514,7 +1517,10 @@ class PostDocumentView(GenericAPIView):
 
         os.utime(temp_file_path, times=(t, t))
 
-        if split_pdf and magic.from_buffer(doc_data, mime=True) == "application/pdf":
+        if (
+            effective_split
+            and magic.from_buffer(doc_data, mime=True) == "application/pdf"
+        ):
             task_ids = []
             base_name = pathvalidate.sanitize_filename(Path(doc_name).stem)
             with Pdf.open(temp_file_path) as pdf:
@@ -1526,7 +1532,9 @@ class PostDocumentView(GenericAPIView):
                         new_pdf.save(split_path)
                     os.utime(split_path, times=(t, t))
                     page_doc = ConsumableDocument(
-                        source=DocumentSource.WebUI if from_webui else DocumentSource.ApiUpload,
+                        source=DocumentSource.WebUI
+                        if from_webui
+                        else DocumentSource.ApiUpload,
                         original_file=split_path,
                     )
                     page_overrides = DocumentMetadataOverrides(
@@ -2298,6 +2306,23 @@ class UiSettingsView(GenericAPIView):
                 "success": True,
             },
         )
+
+
+class SplitPdfSettingView(GenericAPIView):
+    permission_classes = (IsAuthenticated,)
+
+    def get(self, request, format=None):
+        return Response({"value": is_split_enabled()})
+
+    def put(self, request, format=None):
+        serializer = SplitPdfSettingSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        config = ApplicationConfiguration.objects.first()
+        if config is None:
+            config = ApplicationConfiguration.objects.create()
+        config.split_pdf_enabled = serializer.validated_data["value"]
+        config.save(update_fields=["split_pdf_enabled"])
+        return Response({"value": config.split_pdf_enabled})
 
 
 @extend_schema_view(

--- a/src/paperless/config.py
+++ b/src/paperless/config.py
@@ -169,3 +169,8 @@ class GeneralConfig(BaseConfig):
 
         self.app_title = app_config.app_title or None
         self.app_logo = app_config.app_logo.url if app_config.app_logo else None
+
+
+def is_split_enabled() -> bool:
+    app_config = BaseConfig._get_config_instance()
+    return bool(app_config.split_pdf_enabled)

--- a/src/paperless/migrations/0005_applicationconfiguration_split_pdf_enabled.py
+++ b/src/paperless/migrations/0005_applicationconfiguration_split_pdf_enabled.py
@@ -1,0 +1,19 @@
+from django.db import migrations
+from django.db import models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("paperless", "0004_applicationconfiguration_barcode_asn_prefix_and_more"),
+    ]
+
+    operations = [
+        migrations.add_field(
+            model_name="applicationconfiguration",
+            name="split_pdf_enabled",
+            field=models.BooleanField(
+                default=False,
+                verbose_name="Enable splitting of multi-page PDFs",
+            ),
+        ),
+    ]

--- a/src/paperless/models.py
+++ b/src/paperless/models.py
@@ -188,6 +188,11 @@ class ApplicationConfiguration(AbstractSingletonModel):
         upload_to="logo/",
     )
 
+    split_pdf_enabled = models.BooleanField(
+        verbose_name=_("Enable splitting of multi-page PDFs"),
+        default=False,
+    )
+
     """
     Settings for the barcode scanner
     """

--- a/src/paperless/urls.py
+++ b/src/paperless/urls.py
@@ -31,6 +31,7 @@ from documents.views import SearchAutoCompleteView
 from documents.views import SelectionDataView
 from documents.views import SharedLinkView
 from documents.views import ShareLinkViewSet
+from documents.views import SplitPdfSettingView
 from documents.views import StatisticsView
 from documents.views import StoragePathViewSet
 from documents.views import SystemStatusView
@@ -154,6 +155,11 @@ urlpatterns = [
                     "^ui_settings/",
                     UiSettingsView.as_view(),
                     name="ui_settings",
+                ),
+                path(
+                    "settings/split_pdf_enabled/",
+                    SplitPdfSettingView.as_view(),
+                    name="split_pdf_enabled",
                 ),
                 path(
                     "token/",


### PR DESCRIPTION
## Summary
- add global split_pdf_enabled setting with API
- respect split setting during web uploads and consume folder ingestion
- wire frontend upload toggle to persisted server setting

## Testing
- `pre-commit run --files src/paperless/models.py src/paperless/config.py src/paperless/urls.py src/documents/views.py src/documents/serialisers.py src/documents/management/commands/document_consumer.py src-ui/src/app/components/dashboard/widgets/upload-file-widget/upload-file-widget.component.ts src/documents/tests/test_api_split_pdf_setting.py src/documents/tests/test_api_app_config.py src/paperless/migrations/0005_applicationconfiguration_split_pdf_enabled.py`
- `pytest src/documents/tests/test_api_split_pdf_setting.py -q` *(fails: No module named 'corsheaders')*


------
https://chatgpt.com/codex/tasks/task_e_68c6713f0d988330ab8a6120345d4ddd