### PR TITLE
feat: add export status to system status dialog

### DIFF
--- a/src-ui/src/app/components/admin/settings/settings.component.spec.ts
+++ b/src-ui/src/app/components/admin/settings/settings.component.spec.ts
@@ -92,6 +92,9 @@ const status: SystemStatus = {
     sanity_check_status: SystemStatusItemStatus.ERROR,
     sanity_check_last_run: new Date().toISOString(),
     sanity_check_error: 'Error running sanity check.',
+    export_status: SystemStatusItemStatus.OK,
+    export_last_run: new Date().toISOString(),
+    export_error: null,
   },
 }
 

--- a/src-ui/src/app/components/admin/settings/settings.component.ts
+++ b/src-ui/src/app/components/admin/settings/settings.component.ts
@@ -186,6 +186,7 @@ export class SettingsComponent
         SystemStatusItemStatus.ERROR ||
       this.systemStatus.tasks.sanity_check_status ===
         SystemStatusItemStatus.ERROR ||
+      this.systemStatus.tasks.export_status === SystemStatusItemStatus.ERROR ||
       this.systemStatus.websocket_connected === SystemStatusItemStatus.ERROR
     )
   }

--- a/src-ui/src/app/components/common/system-status-dialog/system-status-dialog.component.html
+++ b/src-ui/src/app/components/common/system-status-dialog/system-status-dialog.component.html
@@ -254,18 +254,52 @@
                   <h6><ng-container i18n>Error</ng-container>:</h6> <span class="font-monospace small">{{status.tasks.sanity_check_error}}</span>
                 }
               </ng-template>
-              <dt i18n>WebSocket Connection</dt>
-              <dd>
-                <span class="btn btn-sm pe-none align-items-center btn-dark text-uppercase small">
-                  @if (status.websocket_connected === 'OK') {
-                    <ng-container i18n>OK</ng-container>
-                    <i-bs name="check-circle-fill" class="text-primary ms-2 lh-1"></i-bs>
-                  } @else {
-                    <ng-container i18n>Error</ng-container>
-                    <i-bs name="exclamation-triangle-fill" class="text-danger ms-2 lh-1"></i-bs>
+
+                <dt i18n>Document Exporter</dt>
+                <dd class="d-flex align-items-center">
+                  <button class="btn btn-sm d-flex align-items-center btn-dark text-uppercase small" [ngbPopover]="exporterStatus" triggers="click mouseenter:mouseleave">
+                    {{status.tasks.export_status}}
+                    @if (status.tasks.export_status === 'OK') {
+                      @if (isStale(status.tasks.export_last_run)) {
+                        <i-bs name="exclamation-triangle-fill" class="text-warning ms-2 lh-1"></i-bs>
+                      } @else {
+                        <i-bs name="check-circle-fill" class="text-primary ms-2 lh-1"></i-bs>
+                      }
+                    } @else {
+                      <i-bs name="exclamation-triangle-fill" class="ms-2 lh-1" [class.text-danger]="status.tasks.export_status === SystemStatusItemStatus.ERROR" [class.text-warning]="status.tasks.export_status === SystemStatusItemStatus.WARNING"></i-bs>
+                    }
+                  </button>
+                  @if (currentUserIsSuperUser) {
+                    @if (isRunning(PaperlessTaskName.DocumentExport)) {
+                      <div class="spinner-border spinner-border-sm ms-2" role="status"></div>
+                    } @else {
+                      <button class="btn btn-sm d-flex align-items-center btn-dark small ms-2" (click)="runTask(PaperlessTaskName.DocumentExport)">
+                        <i-bs name="play-fill"></i-bs>&nbsp;
+                        <ng-container i18n>Run Task</ng-container>
+                      </button>
+                    }
                   }
-                </span>
-              </dd>
+                </dd>
+                <ng-template #exporterStatus>
+                  @if (status.tasks.export_status === 'OK') {
+                    <h6><ng-container i18n>Last Run</ng-container>:</h6> <span class="font-monospace small">{{status.tasks.export_last_run | customDate:'medium'}}</span>
+                  } @else {
+                    <h6><ng-container i18n>Error</ng-container>:</h6> <span class="font-monospace small">{{status.tasks.export_error}}</span>
+                  }
+                </ng-template>
+                <dt i18n>WebSocket Connection</dt>
+                <dd>
+                  <span class="btn btn-sm pe-none align-items-center btn-dark text-uppercase small">
+                    @if (status.websocket_connected === 'OK') {
+                      <ng-container i18n>OK</ng-container>
+                      <i-bs name="check-circle-fill" class="text-primary ms-2 lh-1"></i-bs>
+                    } @else {
+                      <ng-container i18n>Error</ng-container>
+                      <i-bs name="exclamation-triangle-fill" class="text-danger ms-2 lh-1"></i-bs>
+                    }
+                  </span>
+                </dd>
+
             </dl>
           </div>
         </div>

--- a/src-ui/src/app/components/common/system-status-dialog/system-status-dialog.component.spec.ts
+++ b/src-ui/src/app/components/common/system-status-dialog/system-status-dialog.component.spec.ts
@@ -68,6 +68,9 @@ const status: SystemStatus = {
     sanity_check_status: SystemStatusItemStatus.OK,
     sanity_check_last_run: new Date().toISOString(),
     sanity_check_error: null,
+    export_status: SystemStatusItemStatus.OK,
+    export_last_run: new Date().toISOString(),
+    export_error: null,
   },
 }
 

--- a/src-ui/src/app/data/paperless-task.ts
+++ b/src-ui/src/app/data/paperless-task.ts
@@ -11,6 +11,7 @@ export enum PaperlessTaskName {
   TrainClassifier = 'train_classifier',
   SanityCheck = 'check_sanity',
   IndexOptimize = 'index_optimize',
+  DocumentExport = 'document_export',
 }
 
 export enum PaperlessTaskStatus {

--- a/src-ui/src/app/data/system-status.ts
+++ b/src-ui/src/app/data/system-status.ts
@@ -43,6 +43,9 @@ export interface SystemStatus {
     sanity_check_status: SystemStatusItemStatus
     sanity_check_last_run: string // ISO date string
     sanity_check_error: string
+    export_status: SystemStatusItemStatus
+    export_last_run: string // ISO date string
+    export_error: string
   }
   websocket_connected?: SystemStatusItemStatus // added client-side
 }

--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -565,6 +565,7 @@ class PaperlessTask(ModelWithOwner):
         TRAIN_CLASSIFIER = ("train_classifier", _("Train Classifier"))
         CHECK_SANITY = ("check_sanity", _("Check Sanity"))
         INDEX_OPTIMIZE = ("index_optimize", _("Index Optimize"))
+        DOCUMENT_EXPORT = ("document_export", _("Document Export"))
 
     task_id = models.CharField(
         max_length=255,

--- a/src/documents/tasks.py
+++ b/src/documents/tasks.py
@@ -11,6 +11,7 @@ from celery import Task
 from celery import shared_task
 from celery import states
 from django.conf import settings
+from django.core.management import call_command
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.db import transaction
@@ -223,6 +224,40 @@ def sanity_check(*, scheduled=True, raise_on_error=True):
         return "Sanity check exited with infos. See log."
     else:
         return "No issues detected."
+
+
+@shared_task
+def export_documents(*, scheduled=True):
+    task = PaperlessTask.objects.create(
+        type=PaperlessTask.TaskType.SCHEDULED_TASK
+        if scheduled
+        else PaperlessTask.TaskType.MANUAL_TASK,
+        task_id=uuid.uuid4(),
+        task_name=PaperlessTask.TaskName.DOCUMENT_EXPORT,
+        status=states.STARTED,
+        date_created=timezone.now(),
+        date_started=timezone.now(),
+    )
+
+    try:
+        call_command(
+            "document_exporter",
+            settings.EXPORT_DIR,
+            "--use-filename-format",
+            "--no-archive",
+            "--no-thumbnail",
+            "--delete",
+        )
+        task.status = states.SUCCESS
+        task.result = "Export completed successfully"
+    except Exception as e:  # pragma: no cover - best effort
+        logger.warning(f"Document export failed: {e}")
+        task.status = states.FAILURE
+        task.result = str(e)
+
+    task.date_done = timezone.now()
+    task.save(update_fields=["status", "result", "date_done"])
+    return task.result
 
 
 @shared_task

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -169,6 +169,7 @@ from documents.tasks import empty_trash
 from documents.tasks import index_optimize
 from documents.tasks import sanity_check
 from documents.tasks import train_classifier
+from documents.tasks import export_documents
 from documents.templating.filepath import validate_filepath_template_and_render
 from documents.utils import get_boolean
 from paperless import version
@@ -2368,6 +2369,10 @@ class TasksViewSet(ReadOnlyModelViewSet):
             sanity_check,
             {"scheduled": False, "raise_on_error": False},
         ),
+        PaperlessTask.TaskName.DOCUMENT_EXPORT: (
+            export_documents,
+            {"scheduled": False},
+        ),
     }
 
     def get_queryset(self):
@@ -2883,6 +2888,28 @@ class SystemStatusView(PassUserMixin):
             last_sanity_check.date_done if last_sanity_check else None
         )
 
+        last_export = (
+            PaperlessTask.objects.filter(
+                task_name=PaperlessTask.TaskName.DOCUMENT_EXPORT,
+                status__in=[
+                    states.SUCCESS,
+                    states.FAILURE,
+                    states.REVOKED,
+                ],
+            )
+            .order_by("-date_done")
+            .first()
+        )
+        export_status = "OK"
+        export_error = None
+        if last_export is None:
+            export_status = "WARNING"
+            export_error = "No document export tasks found"
+        elif last_export and last_export.status != states.SUCCESS:
+            export_status = "ERROR"
+            export_error = last_export.result
+        export_last_run = last_export.date_done if last_export else None
+
         return Response(
             {
                 "pngx_version": current_version,
@@ -2920,6 +2947,9 @@ class SystemStatusView(PassUserMixin):
                     "sanity_check_status": sanity_check_status,
                     "sanity_check_last_run": sanity_check_last_run,
                     "sanity_check_error": sanity_check_error,
+                    "export_status": export_status,
+                    "export_last_run": export_last_run,
+                    "export_error": export_error,
                 },
             },
         )

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -296,6 +296,11 @@ CONSUMPTION_DIR = __get_path(
     BASE_DIR.parent / "consume",
 )
 
+EXPORT_DIR = __get_path(
+    "PAPERLESS_EXPORT_DIR",
+    BASE_DIR.parent / "export",
+)
+
 # This will be created if it doesn't exist
 SCRATCH_DIR = __get_path(
     "PAPERLESS_SCRATCH_DIR",


### PR DESCRIPTION
## Summary
- include document export in admin system status checks
- show exporter status and manual run option in system status dialog
- update tests and types for export status

## Testing
- `pnpm test` *(fails: process exceeded time and was interrupted)*
- `pytest src/documents/tests/test_api_status.py::TestSystemStatus::test_system_status -q` *(fails: No module named 'celery')*


------
https://chatgpt.com/codex/tasks/task_e_68c67a7c07388330a635b2106cd1fa31