### PR TITLE
Persist split PDF upload toggle state

### DIFF
--- a/src-ui/src/app/components/dashboard/widgets/upload-file-widget/upload-file-widget.component.spec.ts
+++ b/src-ui/src/app/components/dashboard/widgets/upload-file-widget/upload-file-widget.component.spec.ts
@@ -39,14 +39,14 @@ const DEFAULT_STATUSES = [
   new FileStatus(),
   new FileStatus(),
 ]
+const STORAGE_KEY = 'paperless-ngx:upload:split-pdf-on-upload'
 
 describe('UploadFileWidgetComponent', () => {
   let component: UploadFileWidgetComponent
   let fixture: ComponentFixture<UploadFileWidgetComponent>
-  let websocketStatusService: WebsocketStatusService
-  let uploadDocumentsService: UploadDocumentsService
 
   beforeEach(async () => {
+    localStorage.clear()
     TestBed.configureTestingModule({
       imports: [
         RouterTestingModule.withRoutes(routes),
@@ -63,22 +63,22 @@ describe('UploadFileWidgetComponent', () => {
         },
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting(),
-        {
+        {  
           provide: ConfigService,
           useValue: { getConfig: () => of({ split_pdf_on_upload: false }) },
         },
       ],
     }).compileComponents()
-
-    websocketStatusService = TestBed.inject(WebsocketStatusService)
-    uploadDocumentsService = TestBed.inject(UploadDocumentsService)
-    fixture = TestBed.createComponent(UploadFileWidgetComponent)
-    component = fixture.componentInstance
-
-    fixture.detectChanges()
   })
 
+  function createComponent() {
+    fixture = TestBed.createComponent(UploadFileWidgetComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  }
+
   it('should support browse files', () => {
+    createComponent()
     const fileInput = fixture.debugElement.query(By.css('input[type="file"]'))
     const clickSpy = jest.spyOn(fileInput.nativeElement, 'click')
     fixture.debugElement
@@ -88,6 +88,8 @@ describe('UploadFileWidgetComponent', () => {
   })
 
   it('should upload files', () => {
+    createComponent()
+    const uploadDocumentsService = TestBed.inject(UploadDocumentsService)
     const uploadSpy = jest.spyOn(uploadDocumentsService, 'uploadFile')
     const file = new File(
       [new Blob(['testing'], { type: 'application/pdf' })],
@@ -106,6 +108,8 @@ describe('UploadFileWidgetComponent', () => {
   })
 
   it('should generate stats summary', () => {
+    createComponent()
+    const websocketStatusService = TestBed.inject(WebsocketStatusService)
     mockConsumerStatuses(websocketStatusService)
     expect(component.getStatusSummary()).toEqual(
       'Processing: 6, Failed: 1, Added: 4'
@@ -113,11 +117,14 @@ describe('UploadFileWidgetComponent', () => {
   })
 
   it('should report an upload progress summary', () => {
+    createComponent()
+    const websocketStatusService = TestBed.inject(WebsocketStatusService)
     mockConsumerStatuses(websocketStatusService)
     expect(component.getTotalUploadProgress()).toEqual(0.75)
   })
 
   it('should change color by status phase', () => {
+    createComponent()
     const processingStatus = new FileStatus()
     processingStatus.phase = FileStatusPhase.WORKING
     expect(component.getStatusColor(processingStatus)).toEqual('primary')
@@ -132,12 +139,16 @@ describe('UploadFileWidgetComponent', () => {
   })
 
   it('should allow dismissing an alert', () => {
+    createComponent()
+    const websocketStatusService = TestBed.inject(WebsocketStatusService)
     const dismissSpy = jest.spyOn(websocketStatusService, 'dismiss')
     component.dismiss(new FileStatus())
     expect(dismissSpy).toHaveBeenCalled()
   })
 
   it('should allow dismissing completed alerts', fakeAsync(() => {
+    createComponent()
+    const websocketStatusService = TestBed.inject(WebsocketStatusService)
     mockConsumerStatuses(websocketStatusService)
     fixture.detectChanges()
     jest
@@ -149,6 +160,19 @@ describe('UploadFileWidgetComponent', () => {
     fixture.detectChanges()
     expect(dismissSpy).toHaveBeenCalledTimes(4)
   }))
+
+  it('should initialize split preference from persistence', () => {
+    localStorage.setItem(STORAGE_KEY, 'true')
+    createComponent()
+    expect(component.splitOnUpload).toBe(true)
+  })
+
+  it('should update when service preference changes', () => {
+    createComponent()
+    const uploadDocumentsService = TestBed.inject(UploadDocumentsService)
+    uploadDocumentsService.setSplitPdfOnUpload(true)
+    expect(component.splitOnUpload).toBe(true)
+  })
 })
 
 function mockConsumerStatuses(consumerStatusService) {

--- a/src-ui/src/app/components/dashboard/widgets/upload-file-widget/upload-file-widget.component.ts
+++ b/src-ui/src/app/components/dashboard/widgets/upload-file-widget/upload-file-widget.component.ts
@@ -1,5 +1,5 @@
 import { NgClass, NgTemplateOutlet } from '@angular/common'
-import { Component, QueryList, ViewChildren, inject, OnInit } from '@angular/core'
+import { Component, OnDestroy, QueryList, ViewChildren, inject } from '@angular/core'
 import { RouterModule } from '@angular/router'
 import {
   NgbAlert,
@@ -13,7 +13,6 @@ import { SETTINGS_KEYS } from 'src/app/data/ui-settings'
 import { IfPermissionsDirective } from 'src/app/directives/if-permissions.directive'
 import { SettingsService } from 'src/app/services/settings.service'
 import { UploadDocumentsService } from 'src/app/services/upload-documents.service'
-import { ConfigService } from 'src/app/services/config.service'
 import {
   FileStatus,
   FileStatusPhase,
@@ -41,26 +40,26 @@ import { FormsModule } from '@angular/forms'
 })
 export class UploadFileWidgetComponent
   extends ComponentWithPermissions
-  implements OnInit
+  implements OnDestroy
 {
   private websocketStatusService = inject(WebsocketStatusService)
   private uploadDocumentsService = inject(UploadDocumentsService)
-  private configService = inject(ConfigService)
   settingsService = inject(SettingsService)
 
   splitOnUpload = false
+  private splitOnUploadSubscription =
+    this.uploadDocumentsService.splitPdfOnUpload$.subscribe((value) => {
+      this.splitOnUpload = value
+    })
 
   @ViewChildren(NgbAlert) alerts: QueryList<NgbAlert>
 
-  ngOnInit() {
-    this.configService.getConfig().subscribe((c) => {
-      this.splitOnUpload = !!c.split_pdf_on_upload
-      this.uploadDocumentsService.setSplitPdfOnUpload(this.splitOnUpload)
-    })
-  }
-
   onSplitOnUploadChange() {
     this.uploadDocumentsService.setSplitPdfOnUpload(this.splitOnUpload)
+  }
+
+  ngOnDestroy(): void {
+    this.splitOnUploadSubscription.unsubscribe()
   }
 
   getStatus() {

--- a/src-ui/src/app/services/upload-documents.service.spec.ts
+++ b/src-ui/src/app/services/upload-documents.service.spec.ts
@@ -17,12 +17,12 @@ import {
 import { ConfigService } from './config.service'
 import { of } from 'rxjs'
 
-describe('UploadDocumentsService', () => {
-  let httpTestingController: HttpTestingController
-  let uploadDocumentsService: UploadDocumentsService
-  let websocketStatusService: WebsocketStatusService
+const STORAGE_KEY = 'paperless-ngx:upload:split-pdf-on-upload'
 
+describe('UploadDocumentsService', () => {
   beforeEach(() => {
+    localStorage.clear()
+
     TestBed.configureTestingModule({
       imports: [],
       providers: [
@@ -36,17 +36,16 @@ describe('UploadDocumentsService', () => {
         provideHttpClientTesting(),
       ],
     })
-
-    httpTestingController = TestBed.inject(HttpTestingController)
-    uploadDocumentsService = TestBed.inject(UploadDocumentsService)
-    websocketStatusService = TestBed.inject(WebsocketStatusService)
   })
 
   afterEach(() => {
-    httpTestingController.verify()
+    TestBed.inject(HttpTestingController).verify()
   })
 
   it('calls post_document api endpoint on upload', () => {
+    const uploadDocumentsService = TestBed.inject(UploadDocumentsService)
+    const httpTestingController = TestBed.inject(HttpTestingController)
+
     const file = new File(
       [new Blob(['testing'], { type: 'application/pdf' })],
       'file.pdf'
@@ -62,6 +61,9 @@ describe('UploadDocumentsService', () => {
   })
 
   it('passes split preference', () => {
+    const uploadDocumentsService = TestBed.inject(UploadDocumentsService)
+    const httpTestingController = TestBed.inject(HttpTestingController)
+
     const file = new File(
       [new Blob(['testing'], { type: 'application/pdf' })],
       'file.pdf'
@@ -76,6 +78,10 @@ describe('UploadDocumentsService', () => {
   })
 
   it('updates progress during upload and failure', () => {
+    const uploadDocumentsService = TestBed.inject(UploadDocumentsService)
+    const websocketStatusService = TestBed.inject(WebsocketStatusService)
+    const httpTestingController = TestBed.inject(HttpTestingController)
+
     const file = new File(
       [new Blob(['testing'], { type: 'application/pdf' })],
       'file.pdf'
@@ -110,6 +116,10 @@ describe('UploadDocumentsService', () => {
   })
 
   it('updates progress on failure', () => {
+    const uploadDocumentsService = TestBed.inject(UploadDocumentsService)
+    const websocketStatusService = TestBed.inject(WebsocketStatusService)
+    const httpTestingController = TestBed.inject(HttpTestingController)
+
     const file = new File(
       [new Blob(['testing'], { type: 'application/pdf' })],
       'file.pdf'
@@ -153,5 +163,37 @@ describe('UploadDocumentsService', () => {
     expect(
       websocketStatusService.getConsumerStatus(FileStatusPhase.FAILED)
     ).toHaveLength(2)
+  })
+
+  it('persists split preference changes', () => {
+    const uploadDocumentsService = TestBed.inject(UploadDocumentsService)
+
+    uploadDocumentsService.setSplitPdfOnUpload(true)
+    expect(localStorage.getItem(STORAGE_KEY)).toEqual('true')
+
+    uploadDocumentsService.setSplitPdfOnUpload(false)
+    expect(localStorage.getItem(STORAGE_KEY)).toEqual('false')
+  })
+
+  it('restores persisted preference on initialization', () => {
+    localStorage.setItem(STORAGE_KEY, 'true')
+
+    const uploadDocumentsService = TestBed.inject(UploadDocumentsService)
+    const httpTestingController = TestBed.inject(HttpTestingController)
+
+    const file = new File(
+      [new Blob(['testing'], { type: 'application/pdf' })],
+      'file.pdf'
+    )
+
+    uploadDocumentsService.uploadFile(file)
+
+    const req = httpTestingController.match(
+      `${environment.apiBaseUrl}documents/post_document/`
+    )
+
+    expect(req[0].request.body.get('split_pdf')).toEqual('true')
+
+    req[0].flush('123-456')
   })
 })

--- a/src-ui/src/app/services/upload-documents.service.ts
+++ b/src-ui/src/app/services/upload-documents.service.ts
@@ -1,12 +1,15 @@
 import { HttpEventType } from '@angular/common/http'
 import { Injectable, inject } from '@angular/core'
-import { Subscription } from 'rxjs'
+import { BehaviorSubject, Subscription } from 'rxjs'
 import { ConfigService } from './config.service'
 import { DocumentService } from './rest/document.service'
 import {
   FileStatusPhase,
   WebsocketStatusService,
 } from './websocket-status.service'
+
+const SPLIT_PDF_ON_UPLOAD_STORAGE_KEY =
+  'paperless-ngx:upload:split-pdf-on-upload'
 
 @Injectable({
   providedIn: 'root',
@@ -18,15 +21,26 @@ export class UploadDocumentsService {
 
   private uploadSubscriptions: Array<Subscription> = []
   private splitPdfOnUpload = false
+  private splitPdfOnUploadSubject = new BehaviorSubject<boolean>(false)
+
+  splitPdfOnUpload$ = this.splitPdfOnUploadSubject.asObservable()
 
   constructor() {
-    this.configService
-      .getConfig()
-      .subscribe((c) => (this.splitPdfOnUpload = !!c.split_pdf_on_upload))
+    const persistedPreference = this.getPersistedSplitPreference()
+    if (persistedPreference !== null) {
+      this.setSplitPdfOnUploadInternal(persistedPreference, false)
+    }
+
+    this.configService.getConfig().subscribe((c) => {
+      const storedPreference = this.getPersistedSplitPreference()
+      const effectivePreference =
+        storedPreference !== null ? storedPreference : !!c.split_pdf_on_upload
+      this.setSplitPdfOnUploadInternal(effectivePreference, false)
+    })
   }
 
-  public setSplitPdfOnUpload(split: boolean) {
-    this.splitPdfOnUpload = split
+  public setSplitPdfOnUpload(split: boolean, persist: boolean = true) {
+    this.setSplitPdfOnUploadInternal(split, persist)
   }
 
   public uploadFile(file: File, splitPdfOnUpload = this.splitPdfOnUpload) {
@@ -72,5 +86,38 @@ export class UploadDocumentsService {
           this.uploadSubscriptions[file.name]?.complete()
         },
       })
+  }
+
+  private setSplitPdfOnUploadInternal(split: boolean, persist: boolean) {
+    if (this.splitPdfOnUpload === split && !persist) {
+      this.splitPdfOnUploadSubject.next(split)
+      return
+    }
+
+    this.splitPdfOnUpload = split
+    this.splitPdfOnUploadSubject.next(split)
+
+    if (persist) {
+      this.persistSplitPreference(split)
+    }
+  }
+
+  private getPersistedSplitPreference(): boolean | null {
+    const storedValue = localStorage.getItem(
+      SPLIT_PDF_ON_UPLOAD_STORAGE_KEY
+    )
+
+    if (storedValue === null) {
+      return null
+    }
+
+    return storedValue === 'true'
+  }
+
+  private persistSplitPreference(split: boolean) {
+    localStorage.setItem(
+      SPLIT_PDF_ON_UPLOAD_STORAGE_KEY,
+      split ? 'true' : 'false'
+    )
   }
 }


### PR DESCRIPTION
## Summary
- persist the split-PDF-on-upload preference in `UploadDocumentsService` and broadcast updates
- keep the dashboard upload widget in sync with the stored preference and clean up subscriptions
- extend service and widget unit tests to cover the persisted toggle behaviour

## Testing
- `cd src-ui && pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68c99fd95e0083308a56430c7bd98d85