### PR TITLE
Persist split PDF toggle on server

### DIFF
--- a/src-ui/src/app/components/dashboard/widgets/upload-file-widget/upload-file-widget.component.html
+++ b/src-ui/src/app/components/dashboard/widgets/upload-file-widget/upload-file-widget.component.html
@@ -1,7 +1,7 @@
 <pngx-widget-frame *pngxIfPermissions="{ action: PermissionAction.Add, type: PermissionType.Document }" [cardless]="true">
   <div content tourAnchor="tour.upload-widget">
     <form class="justify-content-center d-flex flex-column align-items-center">
-      <div class="form-check form-switch align-self-end mb-2">
+      <div class="form-check form-switch align-self-end mb-2 split-toggle">
           <input
             class="form-check-input"
             type="checkbox"

--- a/src-ui/src/app/components/dashboard/widgets/upload-file-widget/upload-file-widget.component.scss
+++ b/src-ui/src/app/components/dashboard/widgets/upload-file-widget/upload-file-widget.component.scss
@@ -2,6 +2,40 @@
   margin-top: -3px;
 }
 
+.split-toggle {
+  .form-check-input {
+    width: 2.75rem;
+    height: 1.5rem;
+    border-radius: 999px;
+    position: relative;
+    background-size: 1.25rem 1.25rem;
+  }
+
+  .form-check-input:not(:checked) {
+    background-color: transparent;
+    border: 2px solid #22c55e;
+    background-image: none;
+    transition: border-color 0.15s ease-in-out, background-color 0.15s ease-in-out;
+  }
+
+  .form-check-input:not(:checked)::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 4px;
+    width: 0.85rem;
+    height: 0.85rem;
+    border-radius: 999px;
+    background-color: #6b7280;
+    transform: translateY(-50%);
+    pointer-events: none;
+  }
+
+  .form-check-input:not(:checked):focus {
+    border-color: #22c55e;
+  }
+}
+
 .btn-outline-dark {
   --bs-btn-border-color: var(--bs-border-color-translucent);
 }

--- a/src-ui/src/app/components/dashboard/widgets/upload-file-widget/upload-file-widget.component.scss
+++ b/src-ui/src/app/components/dashboard/widgets/upload-file-widget/upload-file-widget.component.scss
@@ -3,12 +3,25 @@
 }
 
 .split-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding-left: 0;
+
+  label {
+    margin: 0;
+    line-height: 1;
+  }
+
   .form-check-input {
     width: 2.75rem;
     height: 1.5rem;
     border-radius: 999px;
     position: relative;
     background-size: 1.25rem 1.25rem;
+    margin-left: 0;
+    margin-top: 0;
+    float: none;
   }
 
   .form-check-input:not(:checked) {

--- a/src-ui/src/app/components/dashboard/widgets/upload-file-widget/upload-file-widget.component.spec.ts
+++ b/src-ui/src/app/components/dashboard/widgets/upload-file-widget/upload-file-widget.component.spec.ts
@@ -10,10 +10,13 @@ import { By } from '@angular/platform-browser'
 import { RouterTestingModule } from '@angular/router/testing'
 import { NgxBootstrapIconsModule, allIcons } from 'ngx-bootstrap-icons'
 import { routes } from 'src/app/app-routing.module'
+import { SETTINGS_KEYS } from 'src/app/data/ui-settings'
 import { PermissionsGuard } from 'src/app/guards/permissions.guard'
 import { PermissionsService } from 'src/app/services/permissions.service'
 import { UploadDocumentsService } from 'src/app/services/upload-documents.service'
 import { ConfigService } from 'src/app/services/config.service'
+import { SettingsService } from 'src/app/services/settings.service'
+import { ToastService } from 'src/app/services/toast.service'
 import {
   FileStatus,
   FileStatusPhase,
@@ -39,14 +42,27 @@ const DEFAULT_STATUSES = [
   new FileStatus(),
   new FileStatus(),
 ]
-const STORAGE_KEY = 'paperless-ngx:upload:split-pdf-on-upload'
+class SettingsServiceStub {
+  private values = new Map<string, any>()
+
+  get(key: string) {
+    return this.values.has(key) ? this.values.get(key) : null
+  }
+
+  set(key: string, value: any) {
+    this.values.set(key, value)
+  }
+
+  storeSettings() {
+    return of({})
+  }
+}
 
 describe('UploadFileWidgetComponent', () => {
   let component: UploadFileWidgetComponent
   let fixture: ComponentFixture<UploadFileWidgetComponent>
 
   beforeEach(async () => {
-    localStorage.clear()
     TestBed.configureTestingModule({
       imports: [
         RouterTestingModule.withRoutes(routes),
@@ -63,9 +79,17 @@ describe('UploadFileWidgetComponent', () => {
         },
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting(),
-        {  
+        {
           provide: ConfigService,
           useValue: { getConfig: () => of({ split_pdf_on_upload: false }) },
+        },
+        {
+          provide: SettingsService,
+          useClass: SettingsServiceStub,
+        },
+        {
+          provide: ToastService,
+          useValue: { showError: jest.fn() },
         },
       ],
     }).compileComponents()
@@ -162,7 +186,10 @@ describe('UploadFileWidgetComponent', () => {
   }))
 
   it('should initialize split preference from persistence', () => {
-    localStorage.setItem(STORAGE_KEY, 'true')
+    const settingsService = TestBed.inject(
+      SettingsService
+    ) as unknown as SettingsServiceStub
+    settingsService.set(SETTINGS_KEYS.SPLIT_PDF_ENABLED, true)
     createComponent()
     expect(component.splitOnUpload).toBe(true)
   })

--- a/src-ui/src/app/data/ui-settings.ts
+++ b/src-ui/src/app/data/ui-settings.ts
@@ -46,6 +46,7 @@ export const SETTINGS_KEYS = {
     'general-settings:notifications:consumer-failed',
   NOTIFICATIONS_CONSUMER_SUPPRESS_ON_DASHBOARD:
     'general-settings:notifications:consumer-suppress-on-dashboard',
+  SPLIT_PDF_ENABLED: 'split_pdf_enabled',
   NOTES_ENABLED: 'general-settings:notes-enabled',
   AUDITLOG_ENABLED: 'general-settings:auditlog-enabled',
   SLIM_SIDEBAR: 'general-settings:slim-sidebar',
@@ -163,6 +164,11 @@ export const SETTINGS: UiSetting[] = [
     key: SETTINGS_KEYS.NOTIFICATIONS_CONSUMER_SUPPRESS_ON_DASHBOARD,
     type: 'boolean',
     default: true,
+  },
+  {
+    key: SETTINGS_KEYS.SPLIT_PDF_ENABLED,
+    type: 'boolean',
+    default: null,
   },
   {
     key: SETTINGS_KEYS.NOTES_ENABLED,

--- a/src-ui/src/app/services/upload-documents.service.spec.ts
+++ b/src-ui/src/app/services/upload-documents.service.spec.ts
@@ -8,6 +8,7 @@ import {
   provideHttpClientTesting,
 } from '@angular/common/http/testing'
 import { TestBed } from '@angular/core/testing'
+import { SETTINGS_KEYS } from '../data/ui-settings'
 import { environment } from 'src/environments/environment'
 import { UploadDocumentsService } from './upload-documents.service'
 import {
@@ -15,14 +16,28 @@ import {
   WebsocketStatusService,
 } from './websocket-status.service'
 import { ConfigService } from './config.service'
+import { SettingsService } from './settings.service'
+import { ToastService } from './toast.service'
 import { of } from 'rxjs'
 
-const STORAGE_KEY = 'paperless-ngx:upload:split-pdf-on-upload'
+class SettingsServiceStub {
+  private values = new Map<string, any>()
+
+  get(key: string) {
+    return this.values.has(key) ? this.values.get(key) : null
+  }
+
+  set(key: string, value: any) {
+    this.values.set(key, value)
+  }
+
+  storeSettings() {
+    return of({})
+  }
+}
 
 describe('UploadDocumentsService', () => {
   beforeEach(() => {
-    localStorage.clear()
-
     TestBed.configureTestingModule({
       imports: [],
       providers: [
@@ -31,6 +46,14 @@ describe('UploadDocumentsService', () => {
         {
           provide: ConfigService,
           useValue: { getConfig: () => of({ split_pdf_on_upload: false }) },
+        },
+        {
+          provide: SettingsService,
+          useClass: SettingsServiceStub,
+        },
+        {
+          provide: ToastService,
+          useValue: { showError: jest.fn() },
         },
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting(),
@@ -167,17 +190,28 @@ describe('UploadDocumentsService', () => {
 
   it('persists split preference changes', () => {
     const uploadDocumentsService = TestBed.inject(UploadDocumentsService)
-
+    const settingsService = TestBed.inject(
+      SettingsService
+    ) as unknown as SettingsServiceStub
+    const storeSpy = jest.spyOn(settingsService, 'storeSettings')
     uploadDocumentsService.setSplitPdfOnUpload(true)
-    expect(localStorage.getItem(STORAGE_KEY)).toEqual('true')
-
+    expect(
+      settingsService.get(SETTINGS_KEYS.SPLIT_PDF_ENABLED)
+    ).toEqual(true)
+    expect(storeSpy).toHaveBeenCalled()
+    storeSpy.mockClear()
     uploadDocumentsService.setSplitPdfOnUpload(false)
-    expect(localStorage.getItem(STORAGE_KEY)).toEqual('false')
+    expect(
+      settingsService.get(SETTINGS_KEYS.SPLIT_PDF_ENABLED)
+    ).toEqual(false)
+    expect(storeSpy).toHaveBeenCalled()
   })
 
   it('restores persisted preference on initialization', () => {
-    localStorage.setItem(STORAGE_KEY, 'true')
-
+    const settingsService = TestBed.inject(
+      SettingsService
+    ) as unknown as SettingsServiceStub
+    settingsService.set(SETTINGS_KEYS.SPLIT_PDF_ENABLED, true)
     const uploadDocumentsService = TestBed.inject(UploadDocumentsService)
     const httpTestingController = TestBed.inject(HttpTestingController)
 

--- a/src-ui/src/app/services/upload-documents.service.ts
+++ b/src-ui/src/app/services/upload-documents.service.ts
@@ -1,15 +1,15 @@
 import { HttpEventType } from '@angular/common/http'
 import { Injectable, inject } from '@angular/core'
-import { BehaviorSubject, Subscription } from 'rxjs'
+import { BehaviorSubject, Subscription, first } from 'rxjs'
+import { SETTINGS_KEYS } from '../data/ui-settings'
 import { ConfigService } from './config.service'
 import { DocumentService } from './rest/document.service'
 import {
   FileStatusPhase,
   WebsocketStatusService,
 } from './websocket-status.service'
-
-const SPLIT_PDF_ON_UPLOAD_STORAGE_KEY =
-  'paperless-ngx:upload:split-pdf-on-upload'
+import { SettingsService } from './settings.service'
+import { ToastService } from './toast.service'
 
 @Injectable({
   providedIn: 'root',
@@ -18,6 +18,8 @@ export class UploadDocumentsService {
   private documentService = inject(DocumentService)
   private websocketStatusService = inject(WebsocketStatusService)
   private configService = inject(ConfigService)
+  private settingsService = inject(SettingsService)
+  private toastService = inject(ToastService)
 
   private uploadSubscriptions: Array<Subscription> = []
   private splitPdfOnUpload = false
@@ -26,15 +28,21 @@ export class UploadDocumentsService {
   splitPdfOnUpload$ = this.splitPdfOnUploadSubject.asObservable()
 
   constructor() {
-    const persistedPreference = this.getPersistedSplitPreference()
-    if (persistedPreference !== null) {
+    const persistedPreference = this.settingsService.get(
+      SETTINGS_KEYS.SPLIT_PDF_ENABLED
+    )
+    if (persistedPreference !== null && persistedPreference !== undefined) {
       this.setSplitPdfOnUploadInternal(persistedPreference, false)
     }
 
     this.configService.getConfig().subscribe((c) => {
-      const storedPreference = this.getPersistedSplitPreference()
+      const storedPreference = this.settingsService.get(
+        SETTINGS_KEYS.SPLIT_PDF_ENABLED
+      )
       const effectivePreference =
-        storedPreference !== null ? storedPreference : !!c.split_pdf_on_upload
+        storedPreference !== null && storedPreference !== undefined
+          ? storedPreference
+          : !!c.split_pdf_on_upload
       this.setSplitPdfOnUploadInternal(effectivePreference, false)
     })
   }
@@ -102,22 +110,18 @@ export class UploadDocumentsService {
     }
   }
 
-  private getPersistedSplitPreference(): boolean | null {
-    const storedValue = localStorage.getItem(
-      SPLIT_PDF_ON_UPLOAD_STORAGE_KEY
-    )
-
-    if (storedValue === null) {
-      return null
-    }
-
-    return storedValue === 'true'
-  }
-
   private persistSplitPreference(split: boolean) {
-    localStorage.setItem(
-      SPLIT_PDF_ON_UPLOAD_STORAGE_KEY,
-      split ? 'true' : 'false'
-    )
+    this.settingsService.set(SETTINGS_KEYS.SPLIT_PDF_ENABLED, split)
+    this.settingsService
+      .storeSettings()
+      .pipe(first())
+      .subscribe({
+        error: (error) => {
+          this.toastService.showError(
+            $localize`An error occurred while saving your split PDF preference.`,
+            error
+          )
+        },
+      })
   }
 }

--- a/src/documents/tests/test_api_uisettings.py
+++ b/src/documents/tests/test_api_uisettings.py
@@ -2,6 +2,7 @@ import json
 
 from django.contrib.auth.models import Permission
 from django.contrib.auth.models import User
+from django.conf import settings
 from django.test import override_settings
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -48,6 +49,7 @@ class TestApiUiSettings(DirectoriesMixin, APITestCase):
                 "update_checking": {
                     "backend_setting": "default",
                 },
+                "split_pdf_enabled": settings.CONSUMER_SPLIT_PDF_ON_UPLOAD,
                 "email_enabled": False,
             },
         )

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -2207,6 +2207,11 @@ class UiSettingsView(GenericAPIView):
 
         general_config = GeneralConfig()
 
+        if "split_pdf_enabled" not in ui_settings:
+            ui_settings["split_pdf_enabled"] = (
+                general_config.split_pdf_on_upload
+            )
+
         ui_settings["version"] = version.__full_version_str__
 
         ui_settings["app_title"] = settings.APP_TITLE


### PR DESCRIPTION
## Summary
- add a `split_pdf_enabled` ui setting backed by the api response so the split pdf toggle has a server default
- update the upload documents service to load and persist the toggle through SettingsService instead of localStorage and refresh the related specs
- restyle the split toggle off state with a green outline and grey thumb while keeping the on state unchanged, adjusting the component spec accordingly

## Testing
- `pnpm exec jest --config jest.config.js --runInBand --runTestsByPath src/app/services/upload-documents.service.spec.ts src/app/components/dashboard/widgets/upload-file-widget/upload-file-widget.component.spec.ts`
- `pytest src/documents/tests/test_api_uisettings.py` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68c9dde97f408330b48c6dc99d93f5f5