### PR TITLE
Persist split PDF upload preference

### DIFF
--- a/src-ui/src/app/components/dashboard/widgets/upload-file-widget/upload-file-widget.component.spec.ts
+++ b/src-ui/src/app/components/dashboard/widgets/upload-file-widget/upload-file-widget.component.spec.ts
@@ -21,6 +21,22 @@ import {
 } from 'src/app/services/websocket-status.service'
 import { UploadFileWidgetComponent } from './upload-file-widget.component'
 import { of } from 'rxjs'
+import { SettingsService } from 'src/app/services/settings.service'
+import { SETTINGS_KEYS } from 'src/app/data/ui-settings'
+
+class SettingsServiceStub {
+  private values = new Map<string, any>([[SETTINGS_KEYS.SLIM_SIDEBAR, false]])
+
+  get = jest.fn((key: string) => {
+    return this.values.has(key) ? this.values.get(key) : null
+  })
+
+  set = jest.fn((key: string, value: any) => {
+    this.values.set(key, value)
+  })
+
+  storeSettings = jest.fn(() => of({ success: true }))
+}
 
 const FAILED_STATUSES = [new FileStatus()]
 const WORKING_STATUSES = [new FileStatus(), new FileStatus()]
@@ -45,6 +61,7 @@ describe('UploadFileWidgetComponent', () => {
   let fixture: ComponentFixture<UploadFileWidgetComponent>
   let websocketStatusService: WebsocketStatusService
   let uploadDocumentsService: UploadDocumentsService
+  let settingsService: SettingsServiceStub
 
   beforeEach(async () => {
     TestBed.configureTestingModule({
@@ -67,11 +84,13 @@ describe('UploadFileWidgetComponent', () => {
           provide: ConfigService,
           useValue: { getConfig: () => of({ split_pdf_on_upload: false }) },
         },
+        { provide: SettingsService, useClass: SettingsServiceStub },
       ],
     }).compileComponents()
 
     websocketStatusService = TestBed.inject(WebsocketStatusService)
     uploadDocumentsService = TestBed.inject(UploadDocumentsService)
+    settingsService = TestBed.inject(SettingsService) as unknown as SettingsServiceStub
     fixture = TestBed.createComponent(UploadFileWidgetComponent)
     component = fixture.componentInstance
 
@@ -149,6 +168,37 @@ describe('UploadFileWidgetComponent', () => {
     fixture.detectChanges()
     expect(dismissSpy).toHaveBeenCalledTimes(4)
   }))
+
+  it('persists split preference changes', () => {
+    const setSpy = jest.spyOn(settingsService, 'set')
+    const storeSpy = jest.spyOn(settingsService, 'storeSettings')
+    const uploadSpy = jest.spyOn(
+      uploadDocumentsService,
+      'setSplitPdfOnUpload'
+    )
+
+    component.splitOnUpload = true
+    component.onSplitOnUploadChange()
+
+    expect(uploadSpy).toHaveBeenCalledWith(true)
+    expect(setSpy).toHaveBeenCalledWith(
+      SETTINGS_KEYS.SPLIT_PDF_ON_UPLOAD,
+      true
+    )
+    expect(storeSpy).toHaveBeenCalled()
+  })
+
+  it('uses saved split preference when available', () => {
+    fixture.destroy()
+    settingsService.set(SETTINGS_KEYS.SPLIT_PDF_ON_UPLOAD, true)
+
+    const newFixture = TestBed.createComponent(UploadFileWidgetComponent)
+    const newComponent = newFixture.componentInstance
+
+    newFixture.detectChanges()
+
+    expect(newComponent.splitOnUpload).toBe(true)
+  })
 })
 
 function mockConsumerStatuses(consumerStatusService) {

--- a/src-ui/src/app/components/dashboard/widgets/upload-file-widget/upload-file-widget.component.ts
+++ b/src-ui/src/app/components/dashboard/widgets/upload-file-widget/upload-file-widget.component.ts
@@ -21,6 +21,8 @@ import {
 } from 'src/app/services/websocket-status.service'
 import { WidgetFrameComponent } from '../widget-frame/widget-frame.component'
 import { FormsModule } from '@angular/forms'
+import { first } from 'rxjs'
+import { ToastService } from 'src/app/services/toast.service'
 
 @Component({
   selector: 'pngx-upload-file-widget',
@@ -46,6 +48,7 @@ export class UploadFileWidgetComponent
   private websocketStatusService = inject(WebsocketStatusService)
   private uploadDocumentsService = inject(UploadDocumentsService)
   private configService = inject(ConfigService)
+  private toastService = inject(ToastService)
   settingsService = inject(SettingsService)
 
   splitOnUpload = false
@@ -53,14 +56,49 @@ export class UploadFileWidgetComponent
   @ViewChildren(NgbAlert) alerts: QueryList<NgbAlert>
 
   ngOnInit() {
+    const savedSplitPreference = this.settingsService.get(
+      SETTINGS_KEYS.SPLIT_PDF_ON_UPLOAD
+    )
+
+    if (savedSplitPreference !== null && savedSplitPreference !== undefined) {
+      this.splitOnUpload = savedSplitPreference
+      this.uploadDocumentsService.setSplitPdfOnUpload(this.splitOnUpload)
+    }
+
     this.configService.getConfig().subscribe((c) => {
-      this.splitOnUpload = !!c.split_pdf_on_upload
+      const currentSavedPreference = this.settingsService.get(
+        SETTINGS_KEYS.SPLIT_PDF_ON_UPLOAD
+      )
+
+      if (
+        currentSavedPreference === null ||
+        currentSavedPreference === undefined
+      ) {
+        this.splitOnUpload = !!c.split_pdf_on_upload
+      }
+
       this.uploadDocumentsService.setSplitPdfOnUpload(this.splitOnUpload)
     })
   }
 
   onSplitOnUploadChange() {
     this.uploadDocumentsService.setSplitPdfOnUpload(this.splitOnUpload)
+    this.settingsService.set(
+      SETTINGS_KEYS.SPLIT_PDF_ON_UPLOAD,
+      this.splitOnUpload
+    )
+    this.settingsService
+      .storeSettings()
+      .pipe(first())
+      .subscribe({
+        error: (error) => {
+          this.toastService.showError(
+            $localize`An error occurred while saving settings.`,
+            error
+          )
+          console.warn(error)
+        },
+      })
   }
 
   getStatus() {

--- a/src-ui/src/app/data/ui-settings.ts
+++ b/src-ui/src/app/data/ui-settings.ts
@@ -46,6 +46,7 @@ export const SETTINGS_KEYS = {
     'general-settings:notifications:consumer-failed',
   NOTIFICATIONS_CONSUMER_SUPPRESS_ON_DASHBOARD:
     'general-settings:notifications:consumer-suppress-on-dashboard',
+  SPLIT_PDF_ON_UPLOAD: 'general-settings:upload:split-pdf-on-upload',
   NOTES_ENABLED: 'general-settings:notes-enabled',
   AUDITLOG_ENABLED: 'general-settings:auditlog-enabled',
   SLIM_SIDEBAR: 'general-settings:slim-sidebar',
@@ -163,6 +164,11 @@ export const SETTINGS: UiSetting[] = [
     key: SETTINGS_KEYS.NOTIFICATIONS_CONSUMER_SUPPRESS_ON_DASHBOARD,
     type: 'boolean',
     default: true,
+  },
+  {
+    key: SETTINGS_KEYS.SPLIT_PDF_ON_UPLOAD,
+    type: 'boolean',
+    default: null,
   },
   {
     key: SETTINGS_KEYS.NOTES_ENABLED,


### PR DESCRIPTION
## Summary
- remember the "split PDFs on upload" toggle using a UI setting so the value survives reloads
- initialize the upload widget from either the saved preference or the backend default and persist changes
- extend widget tests with a settings service stub to verify the new persistence logic

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68ca20c020888330921e0416a75870a7