### PR TITLE
Ensure pre-consume scripts run before PDF splitting

### DIFF
--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -50,6 +50,53 @@ from documents.utils import run_subprocess
 from paperless_mail.parsers import MailDocumentParser
 
 
+class PreConsumeScriptError(Exception):
+    """Base exception for pre-consume script execution errors."""
+
+
+class PreConsumeScriptNotFoundError(PreConsumeScriptError):
+    """Raised when the configured pre-consume script does not exist."""
+
+
+def execute_pre_consume_script(
+    *,
+    original_file_path: Path,
+    working_file_path: Path,
+    task_id: str | None,
+    logger,
+) -> None:
+    """Execute the configured pre-consume script with the expected environment."""
+
+    if not settings.PRE_CONSUME_SCRIPT:
+        return
+
+    script_path = Path(settings.PRE_CONSUME_SCRIPT)
+
+    if not script_path.is_file():
+        raise PreConsumeScriptNotFoundError(
+            f"Configured pre-consume script {settings.PRE_CONSUME_SCRIPT} does not exist."
+        )
+
+    logger.info(f"Executing pre-consume script {settings.PRE_CONSUME_SCRIPT}")
+
+    script_env = os.environ.copy()
+    script_env["DOCUMENT_SOURCE_PATH"] = str(original_file_path)
+    script_env["DOCUMENT_WORKING_PATH"] = str(working_file_path)
+    script_env["TASK_ID"] = task_id or ""
+
+    try:
+        run_subprocess(
+            [
+                settings.PRE_CONSUME_SCRIPT,
+                str(original_file_path),
+            ],
+            script_env,
+            logger,
+        )
+    except Exception as exc:  # pragma: no cover - handled by caller
+        raise PreConsumeScriptError from exc
+
+
 class WorkflowTriggerPlugin(
     NoCleanupPluginMixin,
     NoSetupPluginMixin,
@@ -163,42 +210,24 @@ class ConsumerPlugin(
         If one is configured and exists, run the pre-consume script and
         handle its output and/or errors
         """
-        if not settings.PRE_CONSUME_SCRIPT:
-            return
-
-        if not Path(settings.PRE_CONSUME_SCRIPT).is_file():
+        try:
+            execute_pre_consume_script(
+                original_file_path=self.input_doc.original_file,
+                working_file_path=self.working_copy,
+                task_id=self.task_id,
+                logger=self.log,
+            )
+        except PreConsumeScriptNotFoundError as exc:
             self._fail(
                 ConsumerStatusShortMessage.PRE_CONSUME_SCRIPT_NOT_FOUND,
-                f"Configured pre-consume script "
-                f"{settings.PRE_CONSUME_SCRIPT} does not exist.",
+                str(exc),
             )
-
-        self.log.info(f"Executing pre-consume script {settings.PRE_CONSUME_SCRIPT}")
-
-        working_file_path = str(self.working_copy)
-        original_file_path = str(self.input_doc.original_file)
-
-        script_env = os.environ.copy()
-        script_env["DOCUMENT_SOURCE_PATH"] = original_file_path
-        script_env["DOCUMENT_WORKING_PATH"] = working_file_path
-        script_env["TASK_ID"] = self.task_id or ""
-
-        try:
-            run_subprocess(
-                [
-                    settings.PRE_CONSUME_SCRIPT,
-                    original_file_path,
-                ],
-                script_env,
-                self.log,
-            )
-
-        except Exception as e:
+        except PreConsumeScriptError as exc:
             self._fail(
                 ConsumerStatusShortMessage.PRE_CONSUME_SCRIPT_ERROR,
-                f"Error while executing pre-consume script: {e}",
+                f"Error while executing pre-consume script: {exc.__cause__ or exc}",
                 exc_info=True,
-                exception=e,
+                exception=exc.__cause__ or exc,
             )
 
     def run_post_consume_script(self, document: Document):

--- a/src/documents/split_pages.py
+++ b/src/documents/split_pages.py
@@ -8,6 +8,10 @@ from django.conf import settings
 from pikepdf import Page
 from pikepdf import Pdf
 
+from documents.consumer import ConsumerError
+from documents.consumer import execute_pre_consume_script
+from documents.consumer import PreConsumeScriptError
+from documents.consumer import PreConsumeScriptNotFoundError
 from documents.data_models import ConsumableDocument
 from documents.plugins.base import ConsumeTaskPlugin
 from documents.plugins.base import StopConsumeTaskError
@@ -43,6 +47,28 @@ class SplitPagesPlugin(ConsumeTaskPlugin):
 
         if num_pages <= 1:
             return None
+
+        working_copy = Path(self.temp_dir.name) / self.pdf_file.name
+        copy_file_with_basic_stats(self.pdf_file, working_copy)
+
+        try:
+            execute_pre_consume_script(
+                original_file_path=self.pdf_file,
+                working_file_path=working_copy,
+                task_id=self.task_id,
+                logger=logger,
+            )
+        except PreConsumeScriptNotFoundError as exc:
+            raise ConsumerError(str(exc)) from exc
+        except PreConsumeScriptError as exc:
+            raise ConsumerError(
+                f"Error while executing pre-consume script: {exc.__cause__ or exc}"
+            ) from exc
+        else:
+            copy_file_with_basic_stats(working_copy, self.pdf_file)
+        finally:
+            if working_copy.exists():
+                working_copy.unlink()
 
         pages_to_split = {i: True for i in range(1, num_pages)}
 

--- a/src/documents/tests/test_split_pages.py
+++ b/src/documents/tests/test_split_pages.py
@@ -1,4 +1,5 @@
 import shutil
+import tempfile
 from unittest import mock
 
 from django.test import TestCase
@@ -63,3 +64,35 @@ class TestSplitPagesPlugin(
         self.assertEqual(result, "Page splitting complete!")
         self.assertEqual(delay_mock.call_count, 2)
         self.assertIsNotFile(temp_copy)
+
+    @override_settings(CONSUMER_SPLIT_PDF_ON_UPLOAD=True)
+    def test_split_runs_pre_consume_script(self):
+        test_file = self.SAMPLE_DIR / "double-sided-even.pdf"
+        temp_copy = self.dirs.scratch_dir / test_file.name
+        shutil.copy(test_file, temp_copy)
+
+        with tempfile.NamedTemporaryFile() as script:
+            with (
+                override_settings(PRE_CONSUME_SCRIPT=script.name),
+                mock.patch("documents.tasks.ProgressManager", DummyProgressManager),
+                mock.patch("documents.consumer.run_subprocess") as run_mock,
+                mock.patch("documents.tasks.consume_file.delay"),
+            ):
+                tasks.consume_file(
+                    ConsumableDocument(
+                        source=DocumentSource.ConsumeFolder,
+                        original_file=temp_copy,
+                    ),
+                    DocumentMetadataOverrides(),
+                )
+
+        run_mock.assert_called_once()
+
+        args, _ = run_mock.call_args
+        command = args[0]
+        env = args[1]
+
+        self.assertEqual(command[0], script.name)
+        self.assertEqual(command[1], str(temp_copy))
+        self.assertEqual(env["DOCUMENT_SOURCE_PATH"], str(temp_copy))
+        self.assertIn("DOCUMENT_WORKING_PATH", env)


### PR DESCRIPTION
## Summary
- extract the pre-consume script execution into a reusable helper
- invoke the helper from the split pages plugin before splitting a PDF so scripts can act on the original file
- cover the change with a unit test that asserts the script is executed when splitting occurs

## Testing
- uv run pytest src/documents/tests/test_split_pages.py *(fails: missing libmagic system dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68cc32b5fca08330a53a2b822afce3a6